### PR TITLE
Fixing Batch Job IDs

### DIFF
--- a/src/cfa_dagster/azure_batch/executor.py
+++ b/src/cfa_dagster/azure_batch/executor.py
@@ -245,8 +245,11 @@ class AzureBatchStepHandler(StepHandler):
 
     def _get_job_id(self, step_handler_context: StepHandlerContext):
         run = step_handler_context.dagster_run
-        run_id = run.tags.get("dagster/backfill") or run.run_id
-        job_id = f"dagster-run-{run_id}"
+        backfill_id = run.tags.get("dagster/backfill") 
+        print(f"backfill_id: '{backfill_id}'")
+        print(f"run_id: '{run.run_id}'")
+        id = backfill_id or run.run_id
+        job_id = f"dagster-run-{id}"
         return job_id
 
     def _get_task_id(self, step_handler_context: StepHandlerContext):


### PR DESCRIPTION
Using the Dagster-supplied 'dagster/backfill' tag as the Batch job ID when available, falling back to the DagsterRun.run_id. This should keep tasks launched at the same time under the same Batch job ID and prevent hitting the Batch pool active job quota limit.
I also updated the Batch tasks IDs to include the partition key to help troubleshooting:
<img width="610" height="420" alt="image" src="https://github.com/user-attachments/assets/f2198155-3660-41b7-b679-7696f2262cbb" />
