### PR TITLE
Added azure-mgmt-resource-subscriptions as a dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "azure-batch==14.2.0",
     "azure-mgmt-appcontainers>=3.2.0",
     "azure-mgmt-resource>=24.0.0",
+    'azure-mgmt-resource-subscriptions>=1.0.0b1",
     "dagster-azure>=0.27.4",
     "dagster-docker>=0.27.4",
     "dagster-postgres>=0.27.4",


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/resources/azure-mgmt-resource-subscriptions

As of last week, the Azure SDK for python has split their dependencies out more granularly, which I believe has caused a breaking change. See also: https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-mgmt-resource_25.0.0. When adding this (azure-mgmt-resource-subscriptions) to my own pyproject toml, uv/python is able to resolve once again.

There may be another way to go about this - we're in pre-release for this package? I may be missing something here.
Additionally, the release notes say that the way we import the package is correct. Marking this is a draft - the changed fixed things for me, but may not be best practice.