### PR TITLE
Gio batch

### DIFF
--- a/src/cfa_dagster/azure_batch/executor.py
+++ b/src/cfa_dagster/azure_batch/executor.py
@@ -267,7 +267,6 @@ class AzureBatchStepHandler(StepHandler):
 
         run_creation_hour = (
             run_record.create_timestamp
-            .date()
             .strftime("%Y-%m-%dT%H")
         )
         log.debug(f"dagster_user: '{dagster_user}'")


### PR DESCRIPTION
The previous technique used the current hour. This is problematic for checking step health and terminating a job once you cross the hour boundary. Additionally, the previous implementation converted from datetime to date, which results in the current_hour always being midnight.
The run creation hour is a fixed field, so this should resolve potential health check or termination issues