### PR TITLE
Gio dga fsio

### DIFF
--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -12,6 +12,7 @@ from .azure_container_app_job.launcher import AzureContainerAppJobRunLauncher
 from .docker.executor import docker_executor
 from .dynamic_graph_asset import (
     DynamicGraphAssetExecutionContext,
+    DynamicGraphAssetMetadata,
     dynamic_graph_asset,
 )
 from .execution import (

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -152,7 +152,7 @@ class FilesystemADLS2IOManager(UPathIOManager):
             log.debug(f"output_metadata: '{io_metadata}'")
         dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
 
-        if not dga_metadata:
+        if not dga_metadata or dga_metadata.should_return_parent:
             return paths
 
         # Build a new dict of paths with graph_dimensions appended
@@ -182,7 +182,11 @@ class FilesystemADLS2IOManager(UPathIOManager):
             log.debug(f"output_metadata: '{io_metadata}'")
         dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
 
-        if not dga_metadata or dga_metadata.asset_partition_keys:
+        if (
+            not dga_metadata
+            or dga_metadata.asset_partition_keys
+            or dga_metadata.should_return_parent
+        ):
             return path
         # Append graph_dimensions to the path
         for dim in dga_metadata.graph_dimensions:
@@ -225,9 +229,9 @@ class FilesystemADLS2IOManager(UPathIOManager):
         output_metadata = context.output_metadata
         log.debug(f"output_metadata: '{output_metadata}'")
         dga_metadata = DynamicGraphAssetMetadata.from_metadata(output_metadata)
-        if dga_metadata and dga_metadata.should_suppress_output:
+        if dga_metadata and dga_metadata.should_return_parent:
             log.info(
-                "@dynamic_graph_asset.should_suppress_output==True, ignoring dump_to_path"
+                "@dynamic_graph_asset.should_return_parent==True, ignoring dump_to_path"
             )
             return
 

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Any, Union
@@ -7,6 +8,7 @@ from azure.storage.filedatalake import (
     DataLakeServiceClient,
 )
 from dagster import (
+    AssetKey,
     ConfigurableIOManager,
     InputContext,
     OutputContext,
@@ -18,7 +20,10 @@ from dagster_azure.adls2 import ADLS2DefaultAzureCredential, ADLS2Resource
 from pydantic import Field
 from upath import UPath
 
+from ..dynamic_graph_asset import DynamicGraphAssetMetadata
 from ..utils import is_production
+
+log = logging.getLogger(__name__)
 
 
 class FilesystemADLS2IOManager(UPathIOManager):
@@ -107,6 +112,96 @@ class FilesystemADLS2IOManager(UPathIOManager):
         # and load_from_path to use the Azure SDK directly)
         super().__init__(base_path=UPath(self._prefix))
 
+    def handle_output(self, context: OutputContext, obj: Any):
+        output_metadata = context.output_metadata
+        log.debug(f"output_metadata: '{output_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(output_metadata)
+        if dga_metadata:
+            log.debug(
+                "@dynamic_graph_asset, modifying context to mimic an asset"
+            )
+            has_asset_partitions = not not dga_metadata.asset_partition_keys
+            context.__class__.asset_partition_keys = property(
+                lambda self: dga_metadata.asset_partition_keys
+            )
+            context.__class__.has_asset_partitions = property(
+                lambda self: has_asset_partitions
+            )
+            context.__class__.asset_key = property(
+                lambda self: AssetKey(dga_metadata.asset_key)
+            )
+            context.__class__.has_asset_key = property(
+                lambda self: not not dga_metadata.asset_key
+            )
+            log.debug(
+                f"context.has_asset_partitions: '{context.has_asset_partitions}'"
+            )
+        super().handle_output(context, obj)
+
+    def _get_paths_for_partitions(
+        self, context: Union[InputContext, OutputContext]
+    ) -> dict[str, "UPath"]:
+        paths = super()._get_paths_for_partitions(context)
+        # 2026-04-07 14:40:55,994 - cfa_dagster.azure_adls2.filesystem_io_manager - DEBUG - _get_paths_for_partitions: '{'2026-04-06': PosixUPath('dagster-files/gio/cfa_county_rt/2026-04-06')}'
+        log.debug(f"_get_paths_for_partitions: '{paths}'")
+        if isinstance(context, InputContext):
+            io_metadata = context.definition_metadata
+            log.debug(f"input_metadata: '{io_metadata}'")
+        else:
+            io_metadata = context.output_metadata
+            log.debug(f"output_metadata: '{io_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
+
+        if not dga_metadata:
+            return paths
+
+        # Build a new dict of paths with graph_dimensions appended
+        new_paths = {}
+        for partition_key, base_path in paths.items():
+            # Append the graph dimensions to the UPath
+            final_path = base_path
+            for dim in dga_metadata.graph_dimensions:
+                final_path = final_path / dim
+            new_paths[partition_key] = final_path
+        log.debug(
+            f"_get_paths_for_partitions (with graph_dimensions): '{new_paths}'"
+        )
+        return new_paths
+
+    def _get_path_without_extension(
+        self, context: Union[InputContext, OutputContext]
+    ) -> "UPath":
+        path = super()._get_path_without_extension(context)
+        log.debug(f"_get_path_without_extension: '{path}'")
+
+        if isinstance(context, InputContext):
+            io_metadata = context.definition_metadata
+            log.debug(f"input_metadata: '{io_metadata}'")
+        else:
+            io_metadata = context.output_metadata
+            log.debug(f"output_metadata: '{io_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
+
+        if not dga_metadata or dga_metadata.asset_partition_keys:
+            return path
+        # Append graph_dimensions to the path
+        for dim in dga_metadata.graph_dimensions:
+            path = path / dim
+
+        log.debug(
+            f"_get_path_without_extension (with graph_dimensions): '{path}'"
+        )
+        return path
+
+    def load_input(self, context: InputContext) -> Union[Any, dict[str, Any]]:
+        input_metadata = context.definition_metadata
+        log.debug(f"input_metadata: '{input_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(input_metadata)
+        if dga_metadata:
+            log.debug("@dynamic_graph_asset, returning dummy abfss://")
+            return
+        return super().load_input(context)
+
     # -------------------------------------------------------------------------
     # Path construction
     # -------------------------------------------------------------------------
@@ -127,6 +222,15 @@ class FilesystemADLS2IOManager(UPathIOManager):
         ``obj`` should be a ``pathlib.Path`` pointing to a local file or directory.
         ``path`` is the ADLS2 destination path as constructed by UPathIOManager.
         """
+        output_metadata = context.output_metadata
+        log.debug(f"output_metadata: '{output_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(output_metadata)
+        if dga_metadata and dga_metadata.should_suppress_output:
+            log.info(
+                "@dynamic_graph_asset.should_suppress_output==True, ignoring dump_to_path"
+            )
+            return
+
         if not isinstance(obj, Path):
             raise TypeError(
                 f"{self.__class__.__name__} requires assets to return a pathlib.Path, "
@@ -172,9 +276,12 @@ class FilesystemADLS2IOManager(UPathIOManager):
         """
         adls2_prefix = str(path)
 
+        input_metadata = context.definition_metadata
+        log.debug(f"input_metadata: '{input_metadata}'")
+        dga_metadata = DynamicGraphAssetMetadata.from_metadata(input_metadata)
         # If the downstream asset wants a string, return the ADLS2 URI directly
         # so the asset can use the SDK to selectively download files itself
-        if context.dagster_type.typing_type is str:
+        if context.dagster_type.typing_type is str or dga_metadata:
             return self._uri_for_prefix(adls2_prefix)
 
         # Use the input name (as declared in `ins`) as the local folder name so that

--- a/src/cfa_dagster/azure_container_app_job/__init__.py
+++ b/src/cfa_dagster/azure_container_app_job/__init__.py
@@ -1,0 +1,3 @@
+# ruff: noqa: F401
+from .executor import azure_container_app_job_executor
+from .launcher import AzureContainerAppJobRunLauncher

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -649,7 +649,9 @@ def dynamic_graph_asset(
                     graph_dimensions=list(
                         dynamic_context.graph_dimension.values()
                     ),
-                    asset_partition_keys=dynamic_context.partition_keys if dynamic_context.has_partition_key else [],
+                    asset_partition_keys=dynamic_context.partition_keys
+                    if dynamic_context.has_partition_key
+                    else [],
                 )
 
         # -- output op to return results --
@@ -699,7 +701,9 @@ def dynamic_graph_asset(
                     asset_key=final_asset_key,
                     should_return_parent=True,
                     graph_dimensions=graph_dimensions,
-                    asset_partition_keys=context.partition_keys if context.has_partition_key else [],
+                    asset_partition_keys=context.partition_keys
+                    if context.has_partition_key
+                    else [],
                 )
 
         # -- config mapping --

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -35,16 +35,6 @@ from .execution.utils import ExecutionConfig, SelectorConfig
 log = logging.getLogger(__name__)
 
 
-def _is_register_output_call(node) -> bool:
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "register_output"
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "context"
-    )
-
-
 def _has_return_value(fn) -> bool:
     """Check if a function contains a return statement with a value."""
     source = inspect.getsource(fn)
@@ -56,42 +46,6 @@ def _has_return_value(fn) -> bool:
         if isinstance(node, ast.Return) and node.value is not None:
             return True
     return False
-
-
-def _has_register_output_fn(fn):
-    """
-    Checks if context.register_output was called
-    If it is called, but not as the first line of the function, throws a ValueError
-    """
-    source = textwrap.dedent(inspect.getsource(fn))
-    tree = ast.parse(source)
-
-    fn_def = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == fn.__name__
-    )
-
-    register_output_lines = [
-        node.lineno
-        for node in ast.walk(fn_def)
-        if _is_register_output_call(node)
-    ]
-
-    if not register_output_lines:
-        return False  # optional, not present — fine
-
-    first = fn_def.body[0]
-    if not (
-        isinstance(first, ast.Expr) and _is_register_output_call(first.value)
-    ):
-        raise ValueError(
-            f"@dynamic_graph_asset '{fn.__name__}': context.register_output(...) was "
-            f"found at line(s) {register_output_lines} but must be the first statement "
-            f"of the function if used."
-        )
-    return True
 
 
 # using this causes the code location to crash when running multiple assets at once
@@ -254,11 +208,6 @@ class DynamicGraphAssetMetadata:
         )
 
 
-class _CaptureOutput(Exception):
-    def __init__(self, output: dg.Output):
-        self._output = output
-
-
 class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
     """
     OpExecutionContext subclass that exposes the current graph dimension as a dictionary.
@@ -268,13 +217,10 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
             context.graph_dimension["state"]    # "AK"
             context.graph_dimension["disease"]  # "COVID-19"
 
-    This subclass also exposes a register_output() function to provide an Output for the asset
-    in the absence of the traditional `yield dg.Output or dg.AssetMaterialization`
     """
 
     _mapping_key: dict | None = None
     _mapping_key_names: list[str] = []
-    _should_run_output_fn = False
 
     @property
     def graph_dimension(self) -> dict[str, str]:
@@ -283,25 +229,10 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
             self._mapping_key = dict(zip(self._mapping_key_names, values))
         return self._mapping_key
 
-    def register_output(self, output_fn: Callable[[], dg.Output]) -> dg.Output:
-        log.debug(f"output_fn: '{output_fn}'")
-        log.debug(f"should_run_output_fn: '{self._should_run_output_fn}'")
-        output = None
-        if self._should_run_output_fn:
-            if output_fn:
-                output = output_fn()
-                log.debug(f"output from fn: '{output}'")
-            else:
-                output = dg.Output(dg.Nothing)
-                log.debug("Didn't run output fn")
-            # raise an exception to exit before running the user code
-            raise _CaptureOutput(output)
-
     @staticmethod
     def inject(
         context: dg.OpExecutionContext,
         mapping_key_names: list[str],
-        should_run_output_fn: bool,
     ) -> "DynamicGraphAssetExecutionContext":
         """
         Patch an existing OpExecutionContext instance into a DynamicGraphAssetExecutionContext
@@ -313,7 +244,6 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
         # context = cast(DynamicGraphAssetExecutionContext, context)
         context._mapping_key_names = mapping_key_names
         context._mapping_key = None
-        context._should_run_output_fn = should_run_output_fn
         return context  # type: ignore[return-value]
 
 
@@ -369,7 +299,6 @@ class GraphAssetKwargs(TypedDict, total=False):
     kinds: Optional[AbstractSet[str]] = (None,)
 
 
-# TODO: remove register_output
 # -- Decorator --
 def dynamic_graph_asset(
     graph_dimensions: List[str],
@@ -378,7 +307,7 @@ def dynamic_graph_asset(
     **graph_asset_kwargs: Unpack[GraphAssetKwargs],
 ):
     """
-    Decorator that wires a function into a dynamic graph asset.
+    Decorator that wires a function into a dynamic graph asset to run steps in parallel based on provided Config.
     See https://docs.dagster.io/guides/build/ops/dynamic-graphs#using-dynamic-outputs
     and https://docs.dagster.io/guides/build/assets/graph-backed-assets
 
@@ -550,9 +479,6 @@ def dynamic_graph_asset(
 
         sig = inspect.signature(fn)
 
-        # -- Validate register_output is first --
-        did_register_output = _has_register_output_fn(fn)
-        log.debug(f"did_register_output: '{did_register_output}'")
         does_return_value = inspect.isgeneratorfunction(
             fn
         ) or _has_return_value(fn)
@@ -563,12 +489,6 @@ def dynamic_graph_asset(
                 f"@dynamic_graph_asset '{asset_name}': decorated function must "
                 "have a return type annotation when returning a value. Use list[some_type] "
                 "to return the value from each graph_dimension."
-            )
-
-        if did_register_output and does_return_value:
-            raise ValueError(
-                f"@dynamic_graph_asset '{asset_name}': decorated function can not "
-                f"use both register_output() and return a value. "
             )
 
         # -- Locate the Config parameter --
@@ -603,6 +523,16 @@ def dynamic_graph_asset(
                     f"on {config_cls.__name__} must be an iterable type (e.g. list[str]), "
                     f"got '{field_annotation}'"
                 )
+
+        # capture kwargs from decorated function to be later used in compute op
+        decorated_fn_kwargs = {
+                name
+                for name, param in sig.parameters.items()
+                if param.kind in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    )
+                }
 
         # Determine the base key: explicit key or function name
         base_key = graph_asset_kwargs.get("key") or fn.__name__
@@ -669,27 +599,26 @@ def dynamic_graph_asset(
             name=f"{asset_name}__compute",
             ins={"_": dg.In(dg.Nothing), **op_ins},
             **(
-                {"out": dg.Out(dg.Nothing)}
-                if did_register_output or not does_return_value
-                else {
+                {
                     "out": dg.Out(
                         is_required=False,
                         **(
                             {"io_manager_key": io_manager_key}
                             if io_manager_key
                             else {}
-                        ),
-                    )
-                }
-            ),
+                            ),
+                        )
+                    }
+                if does_return_value
+                else {"out": dg.Out(dg.Nothing)}
+                ),
             config_schema=config_cls.to_config_schema(),
         )
         def compute(context, **kwargs):
-            upstream_kwargs = {k: v for k, v in kwargs.items() if k != "_"}
+            upstream_kwargs = {k: v for k, v in kwargs.items() if k in decorated_fn_kwargs}
             dynamic_context = DynamicGraphAssetExecutionContext.inject(
                 context,
                 graph_dimensions,
-                False,
             )
             config = context.op_config
             log.debug(f"config: '{config}'")
@@ -723,21 +652,20 @@ def dynamic_graph_asset(
             name=f"{asset_name}__output",
             ins={
                 "compute_result": (
-                    dg.In(dg.Nothing)
-                    if did_register_output or not does_return_value
-                    else dg.In(
+                    dg.In(
                         **(
                             {"input_manager_key": io_manager_key}
                             if io_manager_key
                             else {}
-                        ),
+                            ),
                         metadata=DynamicGraphAssetMetadata(
                             asset_key=final_asset_key.path,
-                        ).to_metadata(),
-                    )
-                ),
-                **op_ins,
-            },
+                            ).to_metadata(),
+                        )
+                    if does_return_value
+                    else dg.In(dg.Nothing)
+                    ),
+                },
             config_schema=config_cls.to_config_schema(),
             **(
                 {
@@ -749,27 +677,13 @@ def dynamic_graph_asset(
                         ),
                     )
                 }
-                if did_register_output or does_return_value
+                if does_return_value
                 else {"out": dg.Out(dg.Nothing)}
             ),
             tags=in_process_config.to_run_tags(),
         )
         def output_op(context, **kwargs):
-            config = config_cls(**context.op_config)
-            log.debug(f"kwargs.keys(): '{kwargs.keys()}'")
-
             compute_result = kwargs.get("compute_result")
-            log.debug(f"compute_result: '{compute_result}'")
-            upstream_kwargs = {
-                k: v
-                for k, v in kwargs.items()
-                if k != "_" and k != f"{asset_name}__compute"
-            }
-            dynamic_context = DynamicGraphAssetExecutionContext.inject(
-                context,
-                graph_dimensions,
-                True,
-            )
             if does_return_value:
                 result = compute_result
                 # handle yielded Output
@@ -778,23 +692,11 @@ def dynamic_graph_asset(
                 return add_metadata_to_output(
                     result=result
                     if is_annotated_sequence
-                    else compute_result[0],
+                    else result[0],
                     asset_key=final_asset_key,
                     should_return_parent=True,
                     graph_dimensions=graph_dimensions,
-                    asset_partition_keys=dynamic_context.partition_keys,
-                )
-            if not did_register_output:
-                return
-            try:
-                fn(dynamic_context, config, **upstream_kwargs)
-            except _CaptureOutput as e:
-                return add_metadata_to_output(
-                    result=e._output,
-                    asset_key=final_asset_key,
-                    should_return_parent=True,
-                    graph_dimensions=graph_dimensions,
-                    asset_partition_keys=dynamic_context.partition_keys,
+                    asset_partition_keys=context.partition_keys,
                 )
 
         # -- config mapping --
@@ -816,7 +718,7 @@ def dynamic_graph_asset(
         def _asset(**ins_kwargs):
             keys = gen_config(**ins_kwargs)
             res = keys.map(lambda nothing: compute(_=nothing, **ins_kwargs))
-            return output_op(compute_result=res.collect(), **ins_kwargs)
+            return output_op(compute_result=res.collect())
 
         return _asset
 

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -6,8 +6,11 @@ import re
 import sys
 import textwrap
 from typing import (
+    Any,
     Callable,
+    Dict,
     List,
+    Optional,
     get_origin,
     get_type_hints,
 )
@@ -27,6 +30,19 @@ def _is_register_output_call(node) -> bool:
         and isinstance(node.func.value, ast.Name)
         and node.func.value.id == "context"
     )
+
+
+def _has_return_value(fn) -> bool:
+    """Check if a function contains a return statement with a value."""
+    source = inspect.getsource(fn)
+    # dedent in case it's a method or indented function
+    source = textwrap.dedent(source)
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Return) and node.value is not None:
+            return True
+    return False
 
 
 def _has_register_output_fn(fn):
@@ -133,6 +149,100 @@ def _in_to_asset_in(name: str, op_in: dg.In) -> dg.AssetIn:
     )
 
 
+class DynamicGraphAssetMetadata:
+    """
+    Class to represent dynamic graph asset metadata for Dagster.
+    Replaces the old `has_partitions` boolean with a list of `asset_partition_keys`.
+    """
+
+    def __init__(
+        self,
+        asset_key: List[str],
+        graph_dimensions: Optional[List[str]] = [],
+        should_suppress_output: Optional[bool] = False,
+        asset_partition_keys: Optional[List[str]] = [],
+    ):
+        self.asset_key = asset_key
+        self.asset_partition_keys = asset_partition_keys or []
+        self.graph_dimensions = graph_dimensions or []
+        self.should_suppress_output = should_suppress_output
+
+    @staticmethod
+    def _extract_value(obj: Any) -> Any:
+        """
+        Recursively extract .value from dg.MetadataValue objects.
+        """
+        if isinstance(obj, dg.MetadataValue):
+            return obj.value
+        elif isinstance(obj, dict):
+            return {
+                k: DynamicGraphAssetMetadata._extract_value(v)
+                for k, v in obj.items()
+            }
+        elif isinstance(obj, list):
+            return [DynamicGraphAssetMetadata._extract_value(v) for v in obj]
+        else:
+            return obj
+
+    @classmethod
+    def from_metadata(
+        cls, metadata: Dict[str, Any]
+    ) -> Optional["DynamicGraphAssetMetadata"]:
+        """
+        Construct a DynamicGraphAssetMetadata object from Dagster metadata,
+        handling dg.MetadataValue wrappers.
+        """
+        dynamic_meta = metadata.get("dynamic_graph_asset")
+        if dynamic_meta is None:
+            return None
+
+        dynamic_meta = cls._extract_value(dynamic_meta)
+
+        asset_key = dynamic_meta.get("asset_key", [])
+        asset_partition_keys = dynamic_meta.get("asset_partition_keys", [])
+        graph_dimensions = dynamic_meta.get("graph_dimensions", [])
+        should_suppress_output = dynamic_meta.get(
+            "should_suppress_output", False
+        )
+
+        if not isinstance(asset_key, list) or not isinstance(
+            graph_dimensions, list
+        ):
+            raise TypeError(
+                "Expected 'asset_key' and 'graph_dimensions' to be lists"
+            )
+        if not isinstance(asset_partition_keys, list):
+            raise TypeError("Expected 'asset_partition_keys' to be a list")
+
+        return cls(
+            asset_key=asset_key,
+            graph_dimensions=graph_dimensions,
+            asset_partition_keys=asset_partition_keys,
+            should_suppress_output=should_suppress_output,
+        )
+
+    def to_metadata(self) -> Dict[str, Any]:
+        """
+        Convert the object back into Dagster metadata format (plain Python values).
+        """
+        return {
+            "dynamic_graph_asset": {
+                "asset_key": self.asset_key,
+                "asset_partition_keys": self.asset_partition_keys,
+                "graph_dimensions": self.graph_dimensions,
+                "should_suppress_output": self.should_suppress_output,
+            }
+        }
+
+    def __repr__(self):
+        return (
+            f"DynamicGraphAssetMetadata(asset_key={self.asset_key}, "
+            f"asset_partition_keys={self.asset_partition_keys}, "
+            f"should_suppress_output={self.should_suppress_output}, "
+            f"graph_dimensions={self.graph_dimensions})"
+        )
+
+
 class _CaptureOutput(Exception):
     def __init__(self, output: dg.Output):
         self._output = output
@@ -196,6 +306,37 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
         return context  # type: ignore[return-value]
 
 
+def add_metadata_to_output(
+    result,
+    asset_key: dg.AssetKey,
+    should_suppress_output: Optional[bool] = False,
+    graph_dimensions: Optional[list[str]] = [],
+    asset_partition_keys: Optional[list[str]] = [],
+) -> dg.Output:
+    # Extract user metadata if the user returned an Output
+    if isinstance(result, dg.Output):
+        user_value = result.value
+        user_metadata = result.metadata or {}
+    else:
+        user_value = result
+        user_metadata = {}
+
+    # Merge our graph_dimensions metadata
+    merged_metadata = {
+        **dict(user_metadata),
+        **DynamicGraphAssetMetadata(
+            asset_key=asset_key.path,
+            graph_dimensions=graph_dimensions,
+            asset_partition_keys=asset_partition_keys,
+            should_suppress_output=should_suppress_output,
+        ).to_metadata(),
+    }
+    log.debug(f"merged_metadata: '{merged_metadata}'")
+
+    # Yield a new Output object with merged metadata
+    return dg.Output(value=user_value, metadata=merged_metadata)
+
+
 # -- Decorator --
 def dynamic_graph_asset(
     graph_dimensions: List[str],
@@ -246,11 +387,32 @@ def dynamic_graph_asset(
 
     def decorator(fn):
         asset_name = fn.__name__
+
+        hints = get_type_hints(fn)
+        return_type = hints.get("return")
+        log.debug(f"return_type: '{return_type}'")
+        ann = inspect.signature(fn).return_annotation
+
+        if ann is inspect.Signature.empty:
+            log.debug(fn.__name__, "inspected → no annotation")
+        elif ann is None:
+            log.debug(fn.__name__, "inspected → explicitly returns None")
+        else:
+            log.debug(fn.__name__, f"inspected → returns {ann}")
+
         sig = inspect.signature(fn)
 
         # -- Validate register_output is first --
         did_register_output = _has_register_output_fn(fn)
         log.debug(f"did_register_output: '{did_register_output}'")
+        did_return_value = _has_return_value(fn)
+        log.debug(f"did_return_value: '{did_return_value}'")
+
+        if did_register_output and did_return_value:
+            raise ValueError(
+                f"@dynamic_graph_asset '{asset_name}': decorated function can not "
+                f"use both register_output() and return a value. "
+            )
 
         # -- Locate the Config parameter --
         hints = get_type_hints(fn, globalns=vars(sys.modules[fn.__module__]))
@@ -284,13 +446,35 @@ def dynamic_graph_asset(
                     f"on {config_cls.__name__} must be an iterable type (e.g. list[str]), "
                     f"got '{field_annotation}'"
                 )
+
+        # Determine the base key: explicit key or function name
+        base_key = graph_asset_kwargs.get("key") or fn.__name__
+        final_asset_key = base_key
+
+        # Apply key prefix if provided
+        key_prefix = graph_asset_kwargs.get("key_prefix")
+        if key_prefix:
+            # Support list or single string
+            if isinstance(key_prefix, str):
+                final_asset_key = dg.AssetKey([key_prefix, base_key])
+            elif isinstance(key_prefix, list):
+                final_asset_key = dg.AssetKey(key_prefix + [base_key])
+            else:
+                raise ValueError("key_prefix must be str or list of str")
+        else:
+            final_asset_key = dg.AssetKey(base_key)
+        log.debug(f"final_asset_key: '{final_asset_key}'")
+
+        # check for partitions
+        has_partitions = graph_asset_kwargs.get("partitions_def") is not None
+        log.debug(f"has_partitions: '{has_partitions}'")
+
         # Infer upstream op ins from all parameters that aren't context or config
         inferred_ins = {
             name: dg.In()
             for name in sig.parameters
             if name not in ["config", "context"]
         }
-        dg.AutomationCondition.eager()
 
         # User overrides at op level
         op_ins = {**inferred_ins, **(ins or {})}
@@ -305,9 +489,9 @@ def dynamic_graph_asset(
         log.debug(f"op_ins: '{op_ins}'")
         log.debug(f"asset_ins: '{asset_ins}'")
 
-        # -- gen_config op --
+        # -- config op to create DynamicOutputs for fanout --
         @dg.op(
-            name=f"{asset_name}__gen_config",
+            name=f"{asset_name}__config",
             ins={
                 "_": dg.In(dg.Nothing),
                 **{name: dg.In(dg.Nothing) for name in op_ins},
@@ -323,58 +507,112 @@ def dynamic_graph_asset(
                 mapping_key = _encode_mapping_key(combo)
                 yield dg.DynamicOutput(value=None, mapping_key=mapping_key)
 
-        # -- compute op --
+        # -- compute op to run decorated function body --
         @dg.op(
             name=f"{asset_name}__compute",
             ins={"_": dg.In(dg.Nothing), **op_ins},
-            out=dg.Out(dg.Nothing),
+            **(
+                {"out": dg.Out(dg.Nothing)}
+                if did_register_output or not did_return_value
+                else {}
+            ),
             config_schema=config_cls.to_config_schema(),
         )
         def compute(context, **kwargs):
-            original_values = _decode_mapping_key(context.get_mapping_key())
-            overrides = {
-                k: [v] for k, v in zip(graph_dimensions, original_values)
-            }
-            # override graph_dimensions with dimension values for this iteration
-            config = config_cls(**{**context.op_config, **overrides})
             upstream_kwargs = {k: v for k, v in kwargs.items() if k != "_"}
             dynamic_context = DynamicGraphAssetExecutionContext.inject(
                 context,
                 graph_dimensions,
                 False,
             )
-            fn(dynamic_context, config, **upstream_kwargs)
+            config = context.op_config
+            context.log.info(f"config: '{config}'")
+            graph_dimension = dynamic_context.graph_dimension
+            context.log.info(f"graph_dimension: '{graph_dimension}'")
 
-        # -- output op --
+            is_first_dimension = all(
+                graph_dimension[key] == values[0]
+                for key, values in config.items()
+            )
+            context.log.info(f"is_first_dimension: '{is_first_dimension}'")
+
+            result = fn(dynamic_context, context.op_config, **upstream_kwargs)
+            log.debug(f"compute result: '{result}'")
+            return add_metadata_to_output(
+                result=result,
+                asset_key=final_asset_key,
+                graph_dimensions=list(
+                    dynamic_context.graph_dimension.values()
+                ),
+                asset_partition_keys=dynamic_context.partition_keys,
+            )
+
+        # -- output op to return results --
         @dg.op(
             name=f"{asset_name}__output",
-            ins={"_": dg.In(dg.Nothing), **op_ins},
+            ins={
+                "compute_result": (
+                    dg.In(dg.Nothing)
+                    if did_register_output
+                    else dg.In(
+                        metadata=DynamicGraphAssetMetadata(
+                            asset_key=final_asset_key.path,
+                        ).to_metadata()
+                    )
+                ),
+                **op_ins,
+            },
             config_schema=config_cls.to_config_schema(),
-            **({} if did_register_output else {"out": dg.Out(dg.Nothing)}),
+            **(
+                {}
+                if did_register_output or did_return_value
+                else {"out": dg.Out(dg.Nothing)}
+            ),
             tags=in_process_config.to_run_tags(),
         )
         def output_op(context, **kwargs):
             config = config_cls(**context.op_config)
-            upstream_kwargs = {k: v for k, v in kwargs.items() if k != "_"}
+            log.debug(f"kwargs.keys(): '{kwargs.keys()}'")
+
+            compute_result = kwargs.get("compute_result")
+            log.debug(f"compute_result: '{compute_result}'")
+            upstream_kwargs = {
+                k: v
+                for k, v in kwargs.items()
+                if k != "_" and k != f"{asset_name}__compute"
+            }
             dynamic_context = DynamicGraphAssetExecutionContext.inject(
                 context,
                 graph_dimensions,
                 True,
             )
+            if did_return_value:
+                return add_metadata_to_output(
+                    result=compute_result,
+                    asset_key=final_asset_key,
+                    should_suppress_output=True,
+                    graph_dimensions=graph_dimensions,
+                    asset_partition_keys=dynamic_context.partition_keys,
+                )
             if not did_register_output:
                 return
             try:
                 fn(dynamic_context, config, **upstream_kwargs)
             except _CaptureOutput as e:
-                output = e._output
-                return output
+                return add_metadata_to_output(
+                    result=e._output,
+                    asset_key=final_asset_key,
+                    should_suppress_output=True,
+                    graph_dimensions=graph_dimensions,
+                    asset_partition_keys=dynamic_context.partition_keys,
+                )
 
         # -- config mapping --
         @dg.config_mapping(config_schema=config_cls.to_config_schema())
         def _config_mapping(config):
             ops = {
                 f"{asset_name}__{op}": {"config": config}
-                for op in ("gen_config", "compute", "output")
+                for op in ("config", "compute", "output")
             }
             return ops
 
@@ -388,7 +626,7 @@ def dynamic_graph_asset(
         def _asset(**ins_kwargs):
             keys = gen_config(**ins_kwargs)
             res = keys.map(lambda nothing: compute(_=nothing, **ins_kwargs))
-            return output_op(_=res.collect(), **ins_kwargs)
+            return output_op(compute_result=res.collect(), **ins_kwargs)
 
         return _asset
 

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -10,7 +10,6 @@ from types import GeneratorType
 from typing import (
     AbstractSet,
     Any,
-    Callable,
     Dict,
     List,
     Mapping,
@@ -526,13 +525,14 @@ def dynamic_graph_asset(
 
         # capture kwargs from decorated function to be later used in compute op
         decorated_fn_kwargs = {
-                name
-                for name, param in sig.parameters.items()
-                if param.kind in (
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    inspect.Parameter.KEYWORD_ONLY,
-                    )
-                }
+            name
+            for name, param in sig.parameters.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        }
 
         # Determine the base key: explicit key or function name
         base_key = graph_asset_kwargs.get("key") or fn.__name__
@@ -606,16 +606,18 @@ def dynamic_graph_asset(
                             {"io_manager_key": io_manager_key}
                             if io_manager_key
                             else {}
-                            ),
-                        )
-                    }
+                        ),
+                    )
+                }
                 if does_return_value
                 else {"out": dg.Out(dg.Nothing)}
-                ),
+            ),
             config_schema=config_cls.to_config_schema(),
         )
         def compute(context, **kwargs):
-            upstream_kwargs = {k: v for k, v in kwargs.items() if k in decorated_fn_kwargs}
+            upstream_kwargs = {
+                k: v for k, v in kwargs.items() if k in decorated_fn_kwargs
+            }
             dynamic_context = DynamicGraphAssetExecutionContext.inject(
                 context,
                 graph_dimensions,
@@ -657,15 +659,15 @@ def dynamic_graph_asset(
                             {"input_manager_key": io_manager_key}
                             if io_manager_key
                             else {}
-                            ),
+                        ),
                         metadata=DynamicGraphAssetMetadata(
                             asset_key=final_asset_key.path,
-                            ).to_metadata(),
-                        )
+                        ).to_metadata(),
+                    )
                     if does_return_value
                     else dg.In(dg.Nothing)
-                    ),
-                },
+                ),
+            },
             config_schema=config_cls.to_config_schema(),
             **(
                 {
@@ -690,9 +692,7 @@ def dynamic_graph_asset(
                 if isinstance(result, GeneratorType):
                     result = next(result)
                 return add_metadata_to_output(
-                    result=result
-                    if is_annotated_sequence
-                    else result[0],
+                    result=result if is_annotated_sequence else result[0],
                     asset_key=final_asset_key,
                     should_return_parent=True,
                     graph_dimensions=graph_dimensions,

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -488,7 +488,7 @@ def dynamic_graph_asset(
         if does_return_value and return_type is None:
             raise ValueError(
                 f"@dynamic_graph_asset '{asset_name}': decorated function must "
-                "have a return type annotation when returning a value. Use list[some_type] "
+                "have a return type annotation when returning a value e.g. -> str. Use list[some_type] "
                 "to return the value from each graph_dimension."
             )
 

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -303,6 +303,7 @@ def dynamic_graph_asset(
     graph_dimensions: List[str],
     ins: dict[str, dg.In] = None,
     io_manager_key: Optional[str] = None,
+    retry_policy: Optional[dg.RetryPolicy] = None,
     **graph_asset_kwargs: Unpack[GraphAssetKwargs],
 ):
     """
@@ -380,6 +381,7 @@ def dynamic_graph_asset(
         code_version (Optional[str]): Version of the code that generates this asset. In
             general, versions should be set only for code that deterministically produces the same
             output when given the same inputs.
+        retry_policy (Optional[RetryPolicy]): The retry policy for this asset.
         key (Optional[CoeercibleToAssetKey]): The key for this asset. If provided, cannot specify key_prefix or name.
 
 
@@ -612,6 +614,7 @@ def dynamic_graph_asset(
                 if does_return_value
                 else {"out": dg.Out(dg.Nothing)}
             ),
+            retry_policy=retry_policy,
             config_schema=config_cls.to_config_schema(),
         )
         def compute(context, **kwargs):

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -446,7 +446,7 @@ def dynamic_graph_asset(
                 value=output_path,
                 metadata={"container": config.base_output_prefix},
             )
-        Returns: abfss://cfadagster/dagster-files/username/my_dynamic_asset/2026-03-20
+        Returns: abfss://cfadagster/dagster-files/username/my_dynamic_asset/2026-04-13
         Downstream dependencies will download the files directly with the following structure:
         my_dynamic_asset/
         └── 2026-04-13
@@ -649,7 +649,7 @@ def dynamic_graph_asset(
                     graph_dimensions=list(
                         dynamic_context.graph_dimension.values()
                     ),
-                    asset_partition_keys=dynamic_context.partition_keys,
+                    asset_partition_keys=dynamic_context.partition_keys if dynamic_context.has_partition_key else [],
                 )
 
         # -- output op to return results --
@@ -699,7 +699,7 @@ def dynamic_graph_asset(
                     asset_key=final_asset_key,
                     should_return_parent=True,
                     graph_dimensions=graph_dimensions,
-                    asset_partition_keys=context.partition_keys,
+                    asset_partition_keys=context.partition_keys if context.has_partition_key else [],
                 )
 
         # -- config mapping --

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -5,17 +5,30 @@ import logging
 import re
 import sys
 import textwrap
+from collections.abc import Sequence
+from types import GeneratorType
 from typing import (
+    AbstractSet,
     Any,
     Callable,
     Dict,
     List,
+    Mapping,
     Optional,
+    TypedDict,
+    Union,
     get_origin,
     get_type_hints,
 )
+from typing import Sequence as TypeSequence
 
 import dagster as dg
+from dagster._core.definitions.events import (
+    CoercibleToAssetKey,
+    CoercibleToAssetKeyPrefix,
+)
+from dagster._core.definitions.metadata import RawMetadataMapping
+from typing_extensions import Unpack
 
 from .execution.utils import ExecutionConfig, SelectorConfig
 
@@ -159,13 +172,13 @@ class DynamicGraphAssetMetadata:
         self,
         asset_key: List[str],
         graph_dimensions: Optional[List[str]] = [],
-        should_suppress_output: Optional[bool] = False,
+        should_return_parent: Optional[bool] = False,
         asset_partition_keys: Optional[List[str]] = [],
     ):
         self.asset_key = asset_key
         self.asset_partition_keys = asset_partition_keys or []
         self.graph_dimensions = graph_dimensions or []
-        self.should_suppress_output = should_suppress_output
+        self.should_return_parent = should_return_parent
 
     @staticmethod
     def _extract_value(obj: Any) -> Any:
@@ -201,9 +214,7 @@ class DynamicGraphAssetMetadata:
         asset_key = dynamic_meta.get("asset_key", [])
         asset_partition_keys = dynamic_meta.get("asset_partition_keys", [])
         graph_dimensions = dynamic_meta.get("graph_dimensions", [])
-        should_suppress_output = dynamic_meta.get(
-            "should_suppress_output", False
-        )
+        should_return_parent = dynamic_meta.get("should_return_parent", False)
 
         if not isinstance(asset_key, list) or not isinstance(
             graph_dimensions, list
@@ -218,7 +229,7 @@ class DynamicGraphAssetMetadata:
             asset_key=asset_key,
             graph_dimensions=graph_dimensions,
             asset_partition_keys=asset_partition_keys,
-            should_suppress_output=should_suppress_output,
+            should_return_parent=should_return_parent,
         )
 
     def to_metadata(self) -> Dict[str, Any]:
@@ -230,7 +241,7 @@ class DynamicGraphAssetMetadata:
                 "asset_key": self.asset_key,
                 "asset_partition_keys": self.asset_partition_keys,
                 "graph_dimensions": self.graph_dimensions,
-                "should_suppress_output": self.should_suppress_output,
+                "should_return_parent": self.should_return_parent,
             }
         }
 
@@ -238,7 +249,7 @@ class DynamicGraphAssetMetadata:
         return (
             f"DynamicGraphAssetMetadata(asset_key={self.asset_key}, "
             f"asset_partition_keys={self.asset_partition_keys}, "
-            f"should_suppress_output={self.should_suppress_output}, "
+            f"should_return_parent={self.should_return_parent}, "
             f"graph_dimensions={self.graph_dimensions})"
         )
 
@@ -309,7 +320,7 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
 def add_metadata_to_output(
     result,
     asset_key: dg.AssetKey,
-    should_suppress_output: Optional[bool] = False,
+    should_return_parent: Optional[bool] = False,
     graph_dimensions: Optional[list[str]] = [],
     asset_partition_keys: Optional[list[str]] = [],
 ) -> dg.Output:
@@ -328,7 +339,7 @@ def add_metadata_to_output(
             asset_key=asset_key.path,
             graph_dimensions=graph_dimensions,
             asset_partition_keys=asset_partition_keys,
-            should_suppress_output=should_suppress_output,
+            should_return_parent=should_return_parent,
         ).to_metadata(),
     }
     log.debug(f"merged_metadata: '{merged_metadata}'")
@@ -337,11 +348,34 @@ def add_metadata_to_output(
     return dg.Output(value=user_value, metadata=merged_metadata)
 
 
+class GraphAssetKwargs(TypedDict, total=False):
+    name: Optional[str] = (None,)
+    description: Optional[str] = (None,)
+    # ins: Optional[Mapping[str, dg.AssetIn]] = None,
+    config: Optional[Union[dg.ConfigMapping, Mapping[str, Any]]] = (None,)
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = (None,)
+    group_name: Optional[str] = (None,)
+    partitions_def: Optional[dg.PartitionsDefinition] = (None,)
+    hooks: Optional[AbstractSet[dg.HookDefinition]] = (None,)
+    metadata: Optional[RawMetadataMapping] = (None,)
+    tags: Optional[Mapping[str, str]] = (None,)
+    owners: Optional[TypeSequence[str]] = (None,)
+    automation_condition: Optional[dg.AutomationCondition] = (None,)
+    backfill_policy: Optional[dg.BackfillPolicy] = (None,)
+    resource_defs: Optional[Mapping[str, dg.ResourceDefinition]] = (None,)
+    check_specs: Optional[TypeSequence[dg.AssetCheckSpec]] = (None,)
+    code_version: Optional[str] = (None,)
+    key: Optional[CoercibleToAssetKey] = (None,)
+    kinds: Optional[AbstractSet[str]] = (None,)
+
+
+# TODO: remove register_output
 # -- Decorator --
 def dynamic_graph_asset(
     graph_dimensions: List[str],
     ins: dict[str, dg.In] = None,
-    **graph_asset_kwargs,
+    io_manager_key: Optional[str] = None,
+    **graph_asset_kwargs: Unpack[GraphAssetKwargs],
 ):
     """
     Decorator that wires a function into a dynamic graph asset.
@@ -352,21 +386,78 @@ def dynamic_graph_asset(
     of graph_dimensions field values. Config fields listed in `graph_dimensions` are unpacked to
     single scalar values inside the function body.
 
-    graph_dimensions values are encoded into the internap op mapping key using _XX_ hex escaping
+    graph_dimensions values are encoded into the internal op mapping key using _XX_ hex escaping
     so original values (including spaces, hyphens, etc.) are recovered exactly in
     the compute op, while safe characters remain human-readable in the Dagster UI.
 
-    Output can be returned by calling context.register_output(Callable[Any, dg.Output]) in
-    the first line of the decorated function.
+    Return type annotations are required since they determine the behavior of the output.
+    To return a single Output, use a simple type like str, int, bool.
+    To return an Output from each graph dimension, use a 'list[some_type]'.
+    This is especially powerful with the ADLS2FilesystemIOManager since you can upload a file or directory for each graph dimension and return the parent directory as the final output.
+    Downstream assets using the ADLS2FilesystemIOManager will download the structured directory automatically.
 
     Args:
         graph_dimensions: List of config field names to fan out over. Must be iterable
                 fields on the Config class (e.g. List[str]). The cartesian
                 product of all fields becomes the set of dynamic mapping keys.
-        **graph_asset_kwargs: Passed through to @dg.graph_asset, e.g.
-                              partitions_def, ins, metadata, etc.
+
+        name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
+            decorated function. The asset's name must be a valid name in Dagster (ie only contains
+            letters, numbers, and underscores) and may not contain Python reserved keywords.
+        description (Optional[str]):
+            A human-readable description of the asset.
+            about the input.
+        ins (Optional[Dict[str, In]]):
+            Information about the inputs to the op. Information provided here will be combined
+            with what can be inferred from the function signature.
+        config (Optional[Union[ConfigMapping], Mapping[str, Any]):
+            Describes how the graph underlying the asset is configured at runtime.
+
+            If a :py:class:`ConfigMapping` object is provided, then the graph takes on the config
+            schema of this object. The mapping will be applied at runtime to generate the config for
+            the graph's constituent nodes.
+
+            If a dictionary is provided, then it will be used as the default run config for the
+            graph. This means it must conform to the config schema of the underlying nodes. Note
+            that the values provided will be viewable and editable in the Dagster UI, so be careful
+            with secrets.
+
+            If no value is provided, then the config schema for the graph is the default (derived
+            from the underlying nodes).
+        key_prefix (Optional[Union[str, Sequence[str]]]): If provided, the asset's key is the
+            concatenation of the key_prefix and the asset's name, which defaults to the name of
+            the decorated function. Each item in key_prefix must be a valid name in Dagster (ie only
+            contains letters, numbers, and underscores) and may not contain Python reserved keywords.
+        group_name (Optional[str]): A string name used to organize multiple assets into groups. If
+            not provided, the name "default" is used.
+        partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
+            compose the asset.
+        hooks (Optional[AbstractSet[HookDefinition]]): A set of hooks to attach to the asset.
+            These hooks will be executed when the asset is materialized.
+        metadata (Optional[RawMetadataMapping]): Dictionary of metadata to be associated with
+            the asset.
+        io_manager_key (Optional[str]): The resource key of the IOManager used
+            for storing the output of the op as an asset, and for loading it in downstream ops
+            (default: "io_manager").
+        tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
+            attached to runs of the asset.
+        owners (Optional[Sequence[str]]): A list of strings representing owners of the asset. Each
+            string can be a user's email address, or a team name prefixed with `team:`,
+            e.g. `team:finops`.
+        kinds (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
+            will be made visible in the Dagster UI.
+        automation_condition (Optional[AutomationCondition]): The AutomationCondition to use
+            for this asset.
+        backfill_policy (Optional[BackfillPolicy]): The BackfillPolicy to use for this asset.
+        code_version (Optional[str]): Version of the code that generates this asset. In
+            general, versions should be set only for code that deterministically produces the same
+            output when given the same inputs.
+        key (Optional[CoeercibleToAssetKey]): The key for this asset. If provided, cannot specify key_prefix or name.
+
 
     Example:
+        Single value for all graph dimensions:
+
         class MyAssetConfig(dg.Config):
             disease: List[str]
             state: List[str]
@@ -377,12 +468,69 @@ def dynamic_graph_asset(
             partitions_def=daily_partitions,
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset):
-            context.register_output(lambda: dg.Output(
+        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> str:
+            my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+            return dg.Output(
                 value=f"staging/{context.partition_key}",
                 metadata={"container": config.base_output_prefix},
-            ))
-            my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+            )
+        Returns: staging/2026-03-10
+
+        Aggregated value from each graph dimension:
+
+        class MyAssetConfig(dg.Config):
+            disease: List[str]
+            state: List[str]
+            container: str
+
+        @dynamic_graph_asset(
+            graph_dimensions=["disease", "state"],
+            partitions_def=daily_partitions,
+            io_manager_key="ADLS2PickleIOManager",
+            ins={"upstream": dg.AssetIn("some_upstream_asset")},
+        )
+        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[str]:
+            result = my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+            return dg.Output(
+                value=result,
+                metadata={"container": config.base_output_prefix},
+            )
+        Returns: [result_1, result_2, ... result_n]
+
+        File from each graph dimension:
+
+        class MyAssetConfig(dg.Config):
+            disease: List[str]
+            state: List[str]
+            container: str
+
+        @dynamic_graph_asset(
+            graph_dimensions=["disease", "state"],
+            partitions_def=daily_partitions,
+            io_manager_key="ADLS2FilesystemIOManager",
+            ins={"upstream": dg.AssetIn("some_upstream_asset")},
+        )
+        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[str]:
+            output_path = my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+            return dg.Output(
+                value=output_path,
+                metadata={"container": config.base_output_prefix},
+            )
+        Returns: abfss://cfadagster/dagster-files/username/my_dynamic_asset/2026-03-20
+        Downstream dependencies will download the files directly with the following structure:
+        my_dynamic_asset/
+        └── 2026-04-13
+            ├── COVID
+            │   ├── AZ
+            │   │   └── COVID_AZ.txt
+            │   └── NY
+            │       └── COVID_NY.txt
+            └── FLU
+                ├── AZ
+                │   └── FLU_AZ.txt
+                └── NY
+                    └── FLU_NY.txt
+
     """
 
     def decorator(fn):
@@ -391,24 +539,33 @@ def dynamic_graph_asset(
         hints = get_type_hints(fn)
         return_type = hints.get("return")
         log.debug(f"return_type: '{return_type}'")
-        ann = inspect.signature(fn).return_annotation
+        origin = get_origin(return_type) or return_type
 
-        if ann is inspect.Signature.empty:
-            log.debug(fn.__name__, "inspected → no annotation")
-        elif ann is None:
-            log.debug(fn.__name__, "inspected → explicitly returns None")
-        else:
-            log.debug(fn.__name__, f"inspected → returns {ann}")
+        is_annotated_sequence = (
+            isinstance(origin, type)
+            and issubclass(origin, Sequence)
+            and not issubclass(origin, (str, bytes))
+        )
+        log.debug(f"is_annotated_sequence: '{is_annotated_sequence}'")
 
         sig = inspect.signature(fn)
 
         # -- Validate register_output is first --
         did_register_output = _has_register_output_fn(fn)
         log.debug(f"did_register_output: '{did_register_output}'")
-        did_return_value = _has_return_value(fn)
-        log.debug(f"did_return_value: '{did_return_value}'")
+        does_return_value = inspect.isgeneratorfunction(
+            fn
+        ) or _has_return_value(fn)
+        log.debug(f"does_return_value: '{does_return_value}'")
 
-        if did_register_output and did_return_value:
+        if does_return_value and return_type is None:
+            raise ValueError(
+                f"@dynamic_graph_asset '{asset_name}': decorated function must "
+                "have a return type annotation when returning a value. Use list[some_type] "
+                "to return the value from each graph_dimension."
+            )
+
+        if did_register_output and does_return_value:
             raise ValueError(
                 f"@dynamic_graph_asset '{asset_name}': decorated function can not "
                 f"use both register_output() and return a value. "
@@ -513,8 +670,17 @@ def dynamic_graph_asset(
             ins={"_": dg.In(dg.Nothing), **op_ins},
             **(
                 {"out": dg.Out(dg.Nothing)}
-                if did_register_output or not did_return_value
-                else {}
+                if did_register_output or not does_return_value
+                else {
+                    "out": dg.Out(
+                        is_required=False,
+                        **(
+                            {"io_manager_key": io_manager_key}
+                            if io_manager_key
+                            else {}
+                        ),
+                    )
+                }
             ),
             config_schema=config_cls.to_config_schema(),
         )
@@ -526,26 +692,31 @@ def dynamic_graph_asset(
                 False,
             )
             config = context.op_config
-            context.log.info(f"config: '{config}'")
+            log.debug(f"config: '{config}'")
             graph_dimension = dynamic_context.graph_dimension
-            context.log.info(f"graph_dimension: '{graph_dimension}'")
+            log.debug(f"graph_dimension: '{graph_dimension}'")
 
             is_first_dimension = all(
-                graph_dimension[key] == values[0]
+                graph_dimension.get(key) == values[0]
                 for key, values in config.items()
+                if key in graph_dimension
             )
-            context.log.info(f"is_first_dimension: '{is_first_dimension}'")
+            log.debug(f"is_first_dimension: '{is_first_dimension}'")
 
             result = fn(dynamic_context, context.op_config, **upstream_kwargs)
+            # handle yielded Output
+            if isinstance(result, GeneratorType):
+                result = next(result)
             log.debug(f"compute result: '{result}'")
-            return add_metadata_to_output(
-                result=result,
-                asset_key=final_asset_key,
-                graph_dimensions=list(
-                    dynamic_context.graph_dimension.values()
-                ),
-                asset_partition_keys=dynamic_context.partition_keys,
-            )
+            if is_annotated_sequence or is_first_dimension:
+                yield add_metadata_to_output(
+                    result=result,
+                    asset_key=final_asset_key,
+                    graph_dimensions=list(
+                        dynamic_context.graph_dimension.values()
+                    ),
+                    asset_partition_keys=dynamic_context.partition_keys,
+                )
 
         # -- output op to return results --
         @dg.op(
@@ -553,19 +724,32 @@ def dynamic_graph_asset(
             ins={
                 "compute_result": (
                     dg.In(dg.Nothing)
-                    if did_register_output
+                    if did_register_output or not does_return_value
                     else dg.In(
+                        **(
+                            {"input_manager_key": io_manager_key}
+                            if io_manager_key
+                            else {}
+                        ),
                         metadata=DynamicGraphAssetMetadata(
                             asset_key=final_asset_key.path,
-                        ).to_metadata()
+                        ).to_metadata(),
                     )
                 ),
                 **op_ins,
             },
             config_schema=config_cls.to_config_schema(),
             **(
-                {}
-                if did_register_output or did_return_value
+                {
+                    "out": dg.Out(
+                        **(
+                            {"io_manager_key": io_manager_key}
+                            if io_manager_key
+                            else {}
+                        ),
+                    )
+                }
+                if did_register_output or does_return_value
                 else {"out": dg.Out(dg.Nothing)}
             ),
             tags=in_process_config.to_run_tags(),
@@ -586,11 +770,17 @@ def dynamic_graph_asset(
                 graph_dimensions,
                 True,
             )
-            if did_return_value:
+            if does_return_value:
+                result = compute_result
+                # handle yielded Output
+                if isinstance(result, GeneratorType):
+                    result = next(result)
                 return add_metadata_to_output(
-                    result=compute_result,
+                    result=result
+                    if is_annotated_sequence
+                    else compute_result[0],
                     asset_key=final_asset_key,
-                    should_suppress_output=True,
+                    should_return_parent=True,
                     graph_dimensions=graph_dimensions,
                     asset_partition_keys=dynamic_context.partition_keys,
                 )
@@ -602,7 +792,7 @@ def dynamic_graph_asset(
                 return add_metadata_to_output(
                     result=e._output,
                     asset_key=final_asset_key,
-                    should_suppress_output=True,
+                    should_return_parent=True,
                     graph_dimensions=graph_dimensions,
                     asset_partition_keys=dynamic_context.partition_keys,
                 )

--- a/src/cfa_dagster/execution/executor.py
+++ b/src/cfa_dagster/execution/executor.py
@@ -23,10 +23,8 @@ from dagster._core.executor.step_delegating import StepDelegatingExecutor
 # ruff: noqa: F401
 from dagster_docker import docker_executor
 
-from cfa_dagster import (
-    azure_batch_executor,
-    azure_container_app_job_executor,
-)
+from ..azure_batch import azure_batch_executor
+from ..azure_container_app_job import azure_container_app_job_executor
 
 # using relative import to avoid circular dependency
 from .step_handler import RoutingStepHandler

--- a/src/cfa_dagster/execution/run_launcher.py
+++ b/src/cfa_dagster/execution/run_launcher.py
@@ -23,10 +23,7 @@ from dagster._serdes.config_class import ConfigurableClassData
 from dagster_docker import DockerRunLauncher
 from typing_extensions import Self
 
-from cfa_dagster import (
-    AzureContainerAppJobRunLauncher,
-)
-
+from ..azure_container_app_job import AzureContainerAppJobRunLauncher
 from .utils import ExecutionConfig, SelectorConfig
 
 log = logging.getLogger(__name__)

--- a/src/cfa_dagster/execution/step_handler.py
+++ b/src/cfa_dagster/execution/step_handler.py
@@ -22,10 +22,8 @@ from dagster._core.executor.step_delegating import (
 # ruff: noqa: F401
 from dagster_docker import docker_executor
 
-from cfa_dagster import (
-    azure_batch_executor,
-    azure_container_app_job_executor,
-)
+from ..azure_batch import azure_batch_executor
+from ..azure_container_app_job import azure_container_app_job_executor
 
 # using relative import to avoid circular dependency
 from .utils import (

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -168,7 +168,7 @@ def start_dev_env(caller_name: str):
             if result.returncode != 0:
                 # explicity pass -f
                 fallback_cmd = base_cmd + ["-f", script]
-                log.debug(f"Running fallback command: '{base_cmd}'")
+                log.info(f"Running fallback command: '{base_cmd}'")
                 fallback_result = subprocess.run(fallback_cmd)
 
                 if fallback_result.returncode != 0:


### PR DESCRIPTION
This PR creates an integration between the `@dynamic_graph_asset` and the `ADLS2FilesystemIOManager` where each graph_dimension can return a file/directory and it will be uploaded to Blob with a structure matching the graph_dimensions. See #57 for more details.

This PR also adds an `io_manager_key` property so users can specify which IOManager they want to use for outputs, similar to the `io_manager_key` property on a normal `@asset`

There is a breaking change:
- `context.register_output()` is replaced with a normal return value accompanied by a return type annotation on the decorated function e.g.
  Before:
  ```
  @dynamic_graph_asset(
      graph_dimensions=["disease"],
  )
  def parallel_asset(
      context: DynamicGraphAssetExecutionContext,
      config: ParallelAssetConfig,
  ):
      context.register_output(lambda: dg.Output("/path/to/data")
      do_some_compute(context.graph_dimension["disease"])
  ```
  After:
  ```
  @dynamic_graph_asset(
      graph_dimensions=["disease"],
  )
  def parallel_asset(
      context: DynamicGraphAssetExecutionContext,
      config: ParallelAssetConfig,
  ) -> str:
      do_some_compute(context.graph_dimension["disease"])
      return "/path/to/data"
  ```

Closes #57 