### PR TITLE
adding overrides to iomanagers

### DIFF
--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -490,6 +490,13 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
         default=is_production(),
     )
     adls2: ResourceDependency[ADLS2Resource]
+    overrides: dict[str, Any] = Field(
+        description=(
+            "Override an upstream dependency input with a configured value e.g."
+            "`upstream_asset: 'static_value_for_testing'`"
+        ),
+        default_factory=dict,
+    )
     max_concurrency: int = Field(
         default=4,
         description=(
@@ -518,6 +525,15 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
+        upstream_key = context.upstream_output.asset_key.to_user_string()
+        context.log.debug(f"upstream_key: {upstream_key}")
+
+        if upstream_key in self.overrides:
+            override = self.overrides[upstream_key]
+            context.log.debug(
+                f"found key: {upstream_key} returning override: {override}"
+            )
+            return override
         return self._internal_io_manager.load_input(context)
 
     def handle_output(self, context: "OutputContext", obj: Any) -> None:

--- a/src/cfa_dagster/azure_adls2/pickle_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/pickle_io_manager.py
@@ -82,6 +82,13 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         default=is_production(),
     )
     adls2: ResourceDependency[ADLS2Resource]
+    overrides: dict[str, Any] = Field(
+        description=(
+            "Override an upstream dependency input with a configured value e.g."
+            "`upstream_asset: 'static_value_for_testing'`"
+        ),
+        default_factory=dict,
+    )
 
     @property
     @cached_method
@@ -104,6 +111,15 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
+        upstream_key = context.upstream_output.asset_key.to_user_string()
+        context.log.debug(f"upstream_key: {upstream_key}")
+
+        if upstream_key in self.overrides:
+            override = self.overrides[upstream_key]
+            context.log.debug(
+                f"found key: {upstream_key} returning override: {override}"
+            )
+            return override
         return self._internal_io_manager.load_input(context)
 
     def handle_output(self, context: "OutputContext", obj: Any) -> None:


### PR DESCRIPTION
Update to allow users to override upstream dependencies with configured values from the Launchpad e.g.
```python
@asset()
def upstream_asset():
  return "upstream_output"

@asset()
def downstream_asset(upstream_asset):
  print(upstream_asset)
```
Launchpad:
```yaml
resources:
  io_manager:
    config:
      overrides:
        upstream_asset: 'some arbitrary value'
```
Running the above will cause `downstream_asset` to print 'some arbitrary value' instead of 'upstream_output'. This is especially useful for local testing when you want to test a downstream asset without materializing anything upstream

Closes #45