### PR TITLE
Fix for DagsterInvariantViolationError relating to Asset Keys

### DIFF
--- a/infra/uv.lock
+++ b/infra/uv.lock
@@ -391,7 +391,7 @@ wheels = [
 
 [[package]]
 name = "cfa-dagster"
-version = "0.1.0"
+version = "1.0.0"
 source = { directory = "../" }
 dependencies = [
     { name = "aiofiles" },
@@ -460,15 +460,15 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-batch", specifier = ">=14.2.0" },
-    { name = "azure-identity", specifier = ">=1.25.0" },
+    { name = "azure-batch", specifier = "~=14.2.0" },
+    { name = "azure-identity", specifier = "~=1.25.0" },
     { name = "azure-mgmt-appcontainers", specifier = "~=4.0.0" },
-    { name = "azure-mgmt-containerinstance" },
-    { name = "azure-mgmt-loganalytics" },
-    { name = "azure-mgmt-msi", specifier = ">=7.1.0" },
-    { name = "azure-mgmt-subscription", specifier = ">=3.1.1" },
+    { name = "azure-mgmt-containerinstance", specifier = "~=10.1.0" },
+    { name = "azure-mgmt-loganalytics", specifier = "~=13.1.0" },
+    { name = "azure-mgmt-msi", specifier = "~=7.1.0" },
+    { name = "azure-mgmt-subscription", specifier = "~=3.1.1" },
     { name = "cfa-dagster", extras = ["dev"], directory = "../" },
-    { name = "requests", specifier = ">=2.32.5" },
+    { name = "requests", specifier = "~=2.32.5" },
 ]
 
 [[package]]
@@ -962,7 +962,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
-    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -525,7 +525,7 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
-        upstream_key = context.upstream_output.asset_key.to_user_string()
+        upstream_key = context.upstream_output.asset_key
         context.log.debug(f"upstream_key: {upstream_key}")
 
         if upstream_key in self.overrides:

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -525,15 +525,17 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
-        upstream_key = context.upstream_output.asset_key
-        context.log.debug(f"upstream_key: {upstream_key}")
+        if context.upstream_output and context.upstream_output.has_asset_key:
+            upstream_key = context.upstream_output.asset_key.to_user_string()
 
-        if upstream_key in self.overrides:
-            override = self.overrides[upstream_key]
-            context.log.debug(
-                f"found key: {upstream_key} returning override: {override}"
-            )
-            return override
+            context.log.debug(f"upstream_key: {upstream_key}")
+
+            if upstream_key in self.overrides:
+                override = self.overrides[upstream_key]
+                context.log.debug(
+                    f"found key: {upstream_key} returning override: {override}"
+                )
+                return override
         return self._internal_io_manager.load_input(context)
 
     def handle_output(self, context: "OutputContext", obj: Any) -> None:

--- a/src/cfa_dagster/azure_adls2/pickle_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/pickle_io_manager.py
@@ -111,7 +111,7 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
-        upstream_key = context.upstream_output.asset_key.to_user_string()
+        upstream_key = context.upstream_output.asset_key
         context.log.debug(f"upstream_key: {upstream_key}")
 
         if upstream_key in self.overrides:

--- a/src/cfa_dagster/azure_adls2/pickle_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/pickle_io_manager.py
@@ -111,15 +111,17 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         )
 
     def load_input(self, context: "InputContext") -> Any:
-        upstream_key = context.upstream_output.asset_key
-        context.log.debug(f"upstream_key: {upstream_key}")
+        if context.upstream_output and context.upstream_output.has_asset_key:
+            upstream_key = context.upstream_output.asset_key.to_user_string()
 
-        if upstream_key in self.overrides:
-            override = self.overrides[upstream_key]
-            context.log.debug(
-                f"found key: {upstream_key} returning override: {override}"
-            )
-            return override
+            context.log.debug(f"upstream_key: {upstream_key}")
+
+            if upstream_key in self.overrides:
+                override = self.overrides[upstream_key]
+                context.log.debug(
+                    f"found key: {upstream_key} returning override: {override}"
+                )
+                return override
         return self._internal_io_manager.load_input(context)
 
     def handle_output(self, context: "OutputContext", obj: Any) -> None:


### PR DESCRIPTION
Attempting to limit the bus factor by exploring my own ability to debug here.
This is a draft; will need to test.

```
dagster._core.errors.DagsterInvariantViolationError: Attempting to access asset_key, but it was not provided when constructing the OutputContext

  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/dagster/_core/execution/plan/execute_plan.py", line 247, in dagster_event_sequence_for_step
    yield from check.generator(step_events)
  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/dagster/_core/execution/plan/execute_step.py", line 469, in core_dagster_event_sequence_for_step
    for event_or_input_value in step_input.source.load_input_object(
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        step_context, input_def
        ^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/dagster/_core/execution/plan/inputs.py", line 381, in load_input_object
    yield from _load_input_with_input_manager(input_manager, load_input_context)
  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/dagster/_core/execution/plan/inputs.py", line 640, in _load_input_with_input_manager
    value = input_manager.load_input(context)
  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/cfa_dagster/azure_adls2/pickle_io_manager.py", line 114, in load_input
    upstream_key = context.upstream_output.asset_key.to_user_string()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2d167fiqzvabqiydny79gazgihdbs209-cfa-dagster-env/lib/python3.13/site-packages/dagster/_core/execution/context/output.py", line 363, in asset_key
    raise DagsterInvariantViolationError(
    ...<2 lines>...
    )
```