### PR TITLE
ci for release, cli updates

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -6,19 +6,10 @@ on:
     branches:
       - main
     paths:
-      - 'src/**'
       - 'pyproject.toml'
-      - 'uv.lock'
-      - 'infra/flake.nix'
-      - 'infra/flake.lock'
-      - 'infra/dagster_defs.py'
-      - 'infra/pyproject.toml'
-      - 'infra/uv.lock'
 
 env:
   IMAGE_NAME: cfa-dagster
-  IMAGE_TAG: ${{ (github.head_ref || github.ref_name) == 'main' && 'latest' || github.head_ref || github.ref_name }}
-  # getting tag from branch name https://stackoverflow.com/a/71158878
 
 jobs:
   build-and-push-image:
@@ -31,6 +22,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@v3
 
+      - name: Extract version tag
+        id: version
+        run: |
+          V=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "tag=v$V" >> "$GITHUB_OUTPUT"
+
       - name: Build Image
         run: nix build infra/#
 
@@ -39,7 +36,7 @@ jobs:
             OWNER='${{ github.repository_owner }}'
             # to lowercase
             OWNER=${OWNER,,}
-            REGISTRY_IMAGE="ghcr.io/$OWNER/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
+            REGISTRY_IMAGE="ghcr.io/$OWNER/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}"
 
             echo 'Pushing to ghcr'
             skopeo copy \
@@ -73,4 +70,6 @@ jobs:
       - name: Deploy Container App
         run: |
           cd infra && uv sync && source .venv/bin/activate
-          DAGSTER_USER=githubactions dagster job execute -f dagster_defs.py -a update_dagster_containerapp
+          DAGSTER_USER=githubactions dg launch \
+            --job update_dagster_containerapp \
+            --config-json '{"ops":{"get_latest_release_tag":{"config":{"image_tag":"${{ steps.version.outputs.tag }}"}}}}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pyproject.toml'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Extract version
+        id: version
+        run: |
+          V=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "tag=v$V" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" --json tagName &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uv build
+          gh release create "${{ steps.version.outputs.tag }}" dist/* --generate-notes

--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -303,7 +303,7 @@ def create_or_update_code_location_aca(
 
 
 @dg.op
-def update_dagster_aca(context):
+def update_dagster_aca(context, image_tag: str):
     credential = DefaultAzureCredential()
 
     subscription_id = next(
@@ -329,7 +329,7 @@ def update_dagster_aca(context):
     # Shared container configuration
     # -----------------------------
     shared_container_args = {
-        "image": "ghcr.io/cdcgov/cfa-dagster:latest",
+        "image": f"ghcr.io/cdcgov/cfa-dagster:{image_tag}",
         "env": [
             {
                 "name": "DAGSTER_POSTGRES_HOST",
@@ -599,9 +599,26 @@ def update_code_location():
     reload_dagster_workspace(did_update)
 
 
+@dg.op(config_schema={"image_tag": dg.Field(dg.String, is_required=False)})
+def get_latest_release_tag(context) -> str:
+    image_tag = context.op_config.get("image_tag")
+    if image_tag:
+        context.log.info(f"Using provided image_tag: {image_tag}")
+        return image_tag
+    resp = requests.get(
+        "https://api.github.com/repos/cdcgov/cfa-dagster/releases/latest",
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    tag_name = resp.json()["tag_name"]
+    context.log.info(f"Latest GitHub release tag: {tag_name}")
+    return tag_name
+
+
 @dg.job
 def update_dagster_containerapp():
-    update_dagster_aca()
+    update_dagster_aca(get_latest_release_tag())
 
 
 @dg.job
@@ -612,6 +629,11 @@ def restart_webserver():
 @dg.job
 def reload_workspace():
     reload_dagster_workspace()
+
+
+@dg.job
+def fetch_latest_release_tag():
+    get_latest_release_tag()
 
 
 cleanup_batch_schedule = dg.ScheduleDefinition(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfa-dagster"
-version = "1.0.0"
+version = "1.1.0"
 description = "CFA libraries for Dagster"
 readme = "README.md"
 authors = [

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -211,9 +211,7 @@ def _run_cli(
         args = add_default_args(raw_args)
     log.debug(f"args: {args}")
 
-    has_subcommand = any(
-        not arg.startswith("-") for arg in raw_args[1:]
-    )
+    has_subcommand = any(not arg.startswith("-") for arg in raw_args[1:])
 
     def should_retry():
         return has_subcommand or retry_without_subcommand
@@ -240,7 +238,11 @@ def _run_cli(
             retry_with_defs_file()
         sys.exit(1)
     except NoArgsIsHelpError:
-        cli(args=["--help"], auto_envvar_prefix=env_prefix, standalone_mode=False)
+        cli(
+            args=["--help"],
+            auto_envvar_prefix=env_prefix,
+            standalone_mode=False,
+        )
         sys.exit(0)
     except UsageError:
         if should_retry():
@@ -256,7 +258,13 @@ def run_dagster_webserver():
     """
     from dagster_webserver.cli import cli
 
-    _run_cli(cli, "DAGSTER_WEBSERVER", "dagster-webserver", always_add_host_port=True, retry_without_subcommand=True)
+    _run_cli(
+        cli,
+        "DAGSTER_WEBSERVER",
+        "dagster-webserver",
+        always_add_host_port=True,
+        retry_without_subcommand=True,
+    )
 
 
 def run_dagster():

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -10,7 +10,7 @@ import dagster as dg
 import psycopg2
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from click.exceptions import UsageError
+from click.exceptions import NoArgsIsHelpError, UsageError
 from dagster._core.definitions.unresolved_asset_job_definition import (
     UnresolvedAssetJobDefinition,
 )
@@ -153,14 +153,26 @@ def set_env_vars(script: str = None):
         os.environ["DAGSTER_HOME"] = dagster_home
 
 
+def _subcommand_is_dev(sys_argv) -> bool:
+    """Check if the first non-flag argument after the program name is 'dev'."""
+    for arg in sys_argv[1:]:
+        if not arg.startswith("-"):
+            return arg in {"dev"}
+    return False
+
+
 def add_default_args(sys_argv) -> list[str]:
     """
-    Strips the first element of sys.argv and adds default host and port args.
+    Strips the first element of sys.argv and adds default host and port args
+    when the subcommand is 'dev'.
     """
     if not sys_argv:
         return []
 
-    args = sys_argv[1:]  # strip the binary
+    args = sys_argv[1:]
+
+    if not _subcommand_is_dev(sys_argv):
+        return args
 
     extra = []
     if "-h" not in args and "--host" not in args:
@@ -171,43 +183,14 @@ def add_default_args(sys_argv) -> list[str]:
     return [*args, *extra]
 
 
-def _add_default_args(sys_argv) -> list[str]:
-    """
-    Strips the first element of sys.argv and adds default host and port args
-    """
-    # separate cmd, subcmd, args
-    if not sys_argv:
-        return []
-
-    if len(sys_argv) > 1 and not sys_argv[1].startswith("-"):
-        subcmd = sys_argv[1]
-        args = sys_argv[2:]
-    else:
-        subcmd = None
-        args = sys_argv[1:]
-
-    extra = []
-    if "-h" not in args and "--host" not in args:
-        extra += ["-h", LOCAL_HOSTNAME]
-
-    if "-p" not in args and "--port" not in args:
-        extra += ["-p", str(LOCAL_PORT)]
-
-    # return cmd, subcmd, args if there is a subcmd else cmd, args
-    if subcmd is not None:
-        result = [subcmd, *extra, *args]
-    else:
-        result = [*extra, *args]
-
-    return result
-
-
 def _run_cli(
     cli,
     env_prefix: str,
     tool_name: str,
     argv: list[str] | None = None,
     defs_file: str = "dagster_defs.py",
+    always_add_host_port: bool = False,
+    retry_without_subcommand: bool = False,
 ):
     """
     Runs a cli tool that can fall back to the default dagster_defs.py file on error
@@ -216,8 +199,24 @@ def _run_cli(
     configure_dev_db()
     raw_args = argv if argv is not None else sys.argv
     log.debug(f"raw_args: {raw_args}")
-    args = add_default_args(raw_args)
+    if always_add_host_port:
+        stripped = raw_args[1:]
+        extra = []
+        if "-h" not in stripped and "--host" not in stripped:
+            extra += ["-h", LOCAL_HOSTNAME]
+        if "-p" not in stripped and "--port" not in stripped:
+            extra += ["-p", str(LOCAL_PORT)]
+        args = [*stripped, *extra]
+    else:
+        args = add_default_args(raw_args)
     log.debug(f"args: {args}")
+
+    has_subcommand = any(
+        not arg.startswith("-") for arg in raw_args[1:]
+    )
+
+    def should_retry():
+        return has_subcommand or retry_without_subcommand
 
     def retry_with_defs_file():
         if Path(defs_file).exists():
@@ -233,14 +232,19 @@ def _run_cli(
     try:
         cli(args=args, auto_envvar_prefix=env_prefix, standalone_mode=False)
     except SystemExit as e:
-        if e.code != 0:
+        if e.code != 0 and should_retry():
             retry_with_defs_file()
         sys.exit(e.code)
     except CheckError:
-        retry_with_defs_file()
+        if should_retry():
+            retry_with_defs_file()
         sys.exit(1)
+    except NoArgsIsHelpError:
+        cli(args=["--help"], auto_envvar_prefix=env_prefix, standalone_mode=False)
+        sys.exit(0)
     except UsageError:
-        retry_with_defs_file()
+        if should_retry():
+            retry_with_defs_file()
         sys.exit(1)
     else:
         sys.exit(0)
@@ -252,7 +256,7 @@ def run_dagster_webserver():
     """
     from dagster_webserver.cli import cli
 
-    _run_cli(cli, "DAGSTER_WEBSERVER", "dagster-webserver")
+    _run_cli(cli, "DAGSTER_WEBSERVER", "dagster-webserver", always_add_host_port=True, retry_without_subcommand=True)
 
 
 def run_dagster():

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "cfa-dagster"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Closes #97 
This PR does the following:
- adds `release.yaml` to create a GitHub release based on the `pyproject.toml` version
- modifies `deploy-infra.yaml` to create and deploy from a release tag (e.g. `v1.0.0`) instead of `latest`
- updates the `cfa-dg`, `cfa-dagster`, and `cfa-dagster-webserver` wrappers to give better error messages and support `dg launch --job`
- bumps the `pyproject.toml` version