### PR TITLE
Set the default azure http logging policy to DEBUG

### DIFF
--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -29,12 +29,11 @@ from ..dynamic_graph_asset import DynamicGraphAssetMetadata
 from ..utils import is_production
 
 log = logging.getLogger(__name__)
+azure_http_logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
 
 InputMode = Literal["path", "download", "reference"]
 
 # TODO: replace DynamicGraphAssetMetadata-based behavior with explicit feature metadata native to this IOManager
-
-
 @dataclass(frozen=True)
 class ADLS2Path:
     """
@@ -687,6 +686,10 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
         description="Whether to use the production storage account for IO",
         default=is_production(),
     )
+    log_azure_http_io: bool = Field(
+        description="Whether to display Azure http policy logs in stderr always or only when explciitly setting the log level to DEBUG or higher.",
+        default=False
+    )
     adls2: ResourceDependency[ADLS2Resource]
     overrides: dict[str, Any] = Field(
         description=(
@@ -719,6 +722,11 @@ class ADLS2FilesystemIOManager(ConfigurableIOManager):
             "Default: False"
         ),
     )
+
+    # By default, this will be false, thus we will only log azure http requests if
+    # the log level is otherwise set to WARNING.
+    if not log_azure_http_io:
+        azure_http_logger.setLevel(logging.DEBUG)
 
     @property
     @cached_method

--- a/src/cfa_dagster/azure_adls2/pickle_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/pickle_io_manager.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any
 
@@ -17,6 +18,7 @@ from pydantic import Field
 
 from ..utils import is_production
 
+azure_http_logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
 
 class ADLS2PickleIOManager(ConfigurableIOManager):
     """Persistent IO manager using Azure Data Lake Storage Gen2 for storage.
@@ -81,6 +83,10 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         description="Whether to use the production storage account for IO",
         default=is_production(),
     )
+    log_azure_http_io: bool = Field(
+        description="Whether to display Azure http policy logs in stderr always or only when explciitly setting the log level to WARNING or higher.",
+        default=False
+    )
     adls2: ResourceDependency[ADLS2Resource]
     overrides: dict[str, Any] = Field(
         description=(
@@ -89,6 +95,11 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         ),
         default_factory=dict,
     )
+
+    # By default, this will be false, thus we will only log azure http requests if
+    # the log level is otherwise set to WARNING.
+    if not log_azure_http_io:
+        azure_http_logger.setLevel(logging.WARNING)
 
     @property
     @cached_method


### PR DESCRIPTION
These logs are generally unnecessary for users.