### PR TITLE
fix: ADLS2FilesystemIOManager outputs when using a multi-partitioned @dynamic_graph_asset

### DIFF
--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -4,8 +4,8 @@
 import logging
 import os
 
-from .azure_adls2.filesystem_path import ADLS2Path
 from .azure_adls2.filesystem_io_manager import ADLS2FilesystemIOManager
+from .azure_adls2.filesystem_path import ADLS2Path
 from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
 from .azure_batch.executor import azure_batch_executor
 from .azure_container_app_job.executor import azure_container_app_job_executor

--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -4,10 +4,8 @@
 import logging
 import os
 
-from .azure_adls2.filesystem_io_manager import (
-    ADLS2FilesystemIOManager,
-    ADLS2Path,
-)
+from .azure_adls2.filesystem_path import ADLS2Path
+from .azure_adls2.filesystem_io_manager import ADLS2FilesystemIOManager
 from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
 from .azure_batch.executor import azure_batch_executor
 from .azure_container_app_job.executor import azure_container_app_job_executor

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -1,17 +1,11 @@
 import logging
 import os
 import tempfile
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Union
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.storage.filedatalake import (
-    DataLakeDirectoryClient,
-    DataLakeFileClient,
-    DataLakeServiceClient,
-    FileSystemClient,
-)
+from azure.storage.filedatalake import DataLakeServiceClient
 from dagster import (
     AssetKey,
     ConfigurableIOManager,
@@ -20,121 +14,20 @@ from dagster import (
     ResourceDependency,
 )
 from dagster._core.storage.upath_io_manager import UPathIOManager
+from dagster._core.definitions.partitions.utils import MultiPartitionKey
+from dagster._core.definitions.partitions.utils.multi import MULTIPARTITION_KEY_DELIMITER
 from dagster._utils.cached_method import cached_method
 from dagster_azure.adls2 import ADLS2DefaultAzureCredential, ADLS2Resource
 from pydantic import Field
 from upath import UPath
-
+from .filesystem_path import ADLS2Path
+from .filesystem_metadata import InputMode
 from ..dynamic_graph_asset import DynamicGraphAssetMetadata
 from ..utils import is_production
 
 log = logging.getLogger(__name__)
 
-InputMode = Literal["path", "download", "reference"]
-
 # TODO: replace DynamicGraphAssetMetadata-based behavior with explicit feature metadata native to this IOManager
-
-
-@dataclass(frozen=True)
-class ADLS2Path:
-    """
-    Represents a path in ADLS2.
-
-    This object provides authenticated access to the underlying Azure SDK
-    clients while also exposing convenience methods for common operations.
-
-    Users can always drop down to the Azure SDK if they need functionality
-    beyond the convenience methods.
-
-    Examples
-    --------
-
-    Download entire asset:
-
-        local_dir = data.download()
-
-    Download only a subfolder:
-
-        parquet_dir = data.download("parquet")
-
-    Access Azure SDK directly:
-
-        directory_client = data.get_directory_client()
-
-        for item in directory_client.get_paths():
-            ...
-    """
-
-    _io_manager: "FilesystemADLS2IOManager"
-    _path: str
-    local_dir: Path
-
-    @property
-    def uri(self) -> str:
-        return self._io_manager._uri_for_prefix(self._path)
-
-    @property
-    def file_system_client(self) -> FileSystemClient:
-        return self._io_manager._file_system_client
-
-    def get_directory_client(self) -> DataLakeDirectoryClient:
-        return self.file_system_client.get_directory_client(self._path)
-
-    def get_file_client(self) -> DataLakeFileClient:
-        return self.file_system_client.get_file_client(self._path)
-
-    def list(self, recursive: bool = False):
-        """
-        List paths beneath this ADLS location.
-
-        Returns Azure SDK PathProperties objects.
-        """
-        return self.file_system_client.get_paths(
-            path=self._path,
-            recursive=recursive,
-        )
-
-    def download(
-        self,
-        relative_path: str | None = None,
-        local_dir: Path | None = None,
-    ) -> Path:
-        """
-        Download this path or a subpath.
-
-        Examples
-        --------
-
-        Download entire asset:
-
-            data.download()
-
-        Download parquet subdirectory:
-
-            data.download("parquet")
-
-        Download nested path:
-
-            data.download("parquet/2026/01")
-        """
-
-        target_path = self._path
-
-        if relative_path:
-            target_path = (Path(target_path) / relative_path).as_posix()
-            if not local_dir:
-                local_dir = self.local_dir / relative_path
-
-        return self._io_manager.download_prefix(
-            adls2_prefix=target_path,
-            local_dir=local_dir,
-        )
-
-    def __str__(self) -> str:
-        return self.uri
-
-    def __repr__(self) -> str:
-        return f"ADLS2Path(uri='{self.uri}')"
 
 
 class FilesystemADLS2IOManager(UPathIOManager):
@@ -227,90 +120,77 @@ class FilesystemADLS2IOManager(UPathIOManager):
         # and load_from_path to use the Azure SDK directly)
         super().__init__(base_path=UPath(self._prefix))
 
+    @staticmethod
+    def _expand_and_combine(
+        real_keys: list[str | MultiPartitionKey],
+        graph_dimensions: list[str],
+    ) -> list[str]:
+        """
+        Normalize partition keys to slash-separated path segments and append
+        graph dimensions.
+
+        MultiPartitionKey already sorts dimensions by name in its __new__,
+        so the pipe-separated string is already in the correct order — we
+        just replace the delimiter.
+        """
+        def normalize(key: str) -> str:
+            return key.replace(MULTIPARTITION_KEY_DELIMITER, "/")
+
+        expanded = [normalize(k) for k in real_keys]
+        dim_suffix = "/".join(graph_dimensions)
+
+        if expanded and dim_suffix:
+            return [f"{key}/{dim_suffix}" for key in expanded]
+        elif dim_suffix:
+            return [dim_suffix]
+        else:
+            return expanded
+
+    @staticmethod
+    def _patch_context(
+        context: InputContext | OutputContext,
+        dga: "DynamicGraphAssetMetadata",
+    ):
+        """
+        Monkey-patch context class properties so the parent UPathIOManager
+        sees the synthetic keys as if they were real Dagster partition keys.
+
+        Patching at the class level is required because Dagster context
+        properties are defined as class-level descriptors.
+        """
+        synthetic_keys = FilesystemADLS2IOManager._expand_and_combine(
+            real_keys=dga.asset_partition_keys,
+            graph_dimensions=dga.graph_dimensions,
+        )
+        has_partitions = bool(synthetic_keys)
+
+        context.__class__.asset_partition_keys = property(lambda self: synthetic_keys)
+        context.__class__.has_asset_partitions = property(lambda self: has_partitions)
+
+        if dga.asset_key:
+            context.__class__.asset_key = property(lambda self: AssetKey(dga.asset_key))
+            context.__class__.has_asset_key = property(lambda self: True)
+
+        log.debug(
+            f"Patched context: asset_key={dga.asset_key}, "
+            f"synthetic_partition_keys={synthetic_keys}"
+        )
+
     def handle_output(self, context: OutputContext, obj: Any):
-        output_metadata = context.output_metadata
-        log.debug(f"output_metadata: '{output_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(output_metadata)
-        if dga_metadata:
-            log.debug(
-                "@dynamic_graph_asset, modifying context to mimic an asset"
-            )
-            has_asset_partitions = not not dga_metadata.asset_partition_keys
-            context.__class__.asset_partition_keys = property(
-                lambda self: dga_metadata.asset_partition_keys
-            )
-            context.__class__.has_asset_partitions = property(
-                lambda self: has_asset_partitions
-            )
-            context.__class__.asset_key = property(
-                lambda self: AssetKey(dga_metadata.asset_key)
-            )
-            context.__class__.has_asset_key = property(
-                lambda self: not not dga_metadata.asset_key
-            )
-            log.debug(
-                f"context.has_asset_partitions: '{context.has_asset_partitions}'"
-            )
+        """
+        On write: read DGA metadata from output_metadata, patch the context,
+        then delegate to the parent which calls dump_to_path at the right path.
+        """
+        output_metadata = context.output_metadata or {}
+        dga = DynamicGraphAssetMetadata.from_metadata(output_metadata)
+
+        if dga and not dga.should_return_parent:
+            log.debug(f"handle_output: DGA metadata found → {dga}")
+            self._patch_context(context, dga)
+        else:
+            log.debug("handle_output: no DGA metadata, using standard behaviour")
+
         super().handle_output(context, obj)
-
-    def _get_paths_for_partitions(
-        self, context: Union[InputContext, OutputContext]
-    ) -> dict[str, "UPath"]:
-        paths = super()._get_paths_for_partitions(context)
-        # 2026-04-07 14:40:55,994 - cfa_dagster.azure_adls2.filesystem_io_manager - DEBUG - _get_paths_for_partitions: '{'2026-04-06': PosixUPath('dagster-files/gio/cfa_county_rt/2026-04-06')}'
-        log.debug(f"_get_paths_for_partitions: '{paths}'")
-        if isinstance(context, InputContext):
-            io_metadata = context.definition_metadata
-            log.debug(f"input_metadata: '{io_metadata}'")
-        else:
-            io_metadata = context.output_metadata
-            log.debug(f"output_metadata: '{io_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
-
-        if not dga_metadata or dga_metadata.should_return_parent:
-            return paths
-
-        # Build a new dict of paths with graph_dimensions appended
-        new_paths = {}
-        for partition_key, base_path in paths.items():
-            # Append the graph dimensions to the UPath
-            final_path = base_path
-            for dim in dga_metadata.graph_dimensions:
-                final_path = final_path / dim
-            new_paths[partition_key] = final_path
-        log.debug(
-            f"_get_paths_for_partitions (with graph_dimensions): '{new_paths}'"
-        )
-        return new_paths
-
-    def _get_path_without_extension(
-        self, context: Union[InputContext, OutputContext]
-    ) -> "UPath":
-        path = super()._get_path_without_extension(context)
-        log.debug(f"_get_path_without_extension: '{path}'")
-
-        if isinstance(context, InputContext):
-            io_metadata = context.definition_metadata
-            log.debug(f"input_metadata: '{io_metadata}'")
-        else:
-            io_metadata = context.output_metadata
-            log.debug(f"output_metadata: '{io_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(io_metadata)
-
-        if (
-            not dga_metadata
-            or dga_metadata.asset_partition_keys
-            or dga_metadata.should_return_parent
-        ):
-            return path
-        # Append graph_dimensions to the path
-        for dim in dga_metadata.graph_dimensions:
-            path = path / dim
-
-        log.debug(
-            f"_get_path_without_extension (with graph_dimensions): '{path}'"
-        )
-        return path
 
     def load_input(self, context: InputContext) -> Union[Any, dict[str, Any]]:
         input_metadata = context.definition_metadata

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -13,21 +13,24 @@ from dagster import (
     OutputContext,
     ResourceDependency,
 )
-from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._core.definitions.partitions.utils import MultiPartitionKey
-from dagster._core.definitions.partitions.utils.multi import MULTIPARTITION_KEY_DELIMITER
+from dagster._core.definitions.partitions.utils.multi import (
+    MULTIPARTITION_KEY_DELIMITER,
+)
+from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._utils.cached_method import cached_method
 from dagster_azure.adls2 import ADLS2DefaultAzureCredential, ADLS2Resource
 from pydantic import Field
 from upath import UPath
-from .filesystem_path import ADLS2Path
-from .filesystem_metadata import InputMode
-from ..dynamic_graph_asset import DynamicGraphAssetMetadata
+
 from ..utils import is_production
+from .filesystem_metadata import (
+    ADLS2FilesystemIOManagerMetadata,
+    InputMode,
+)
+from .filesystem_path import ADLS2Path
 
 log = logging.getLogger(__name__)
-
-# TODO: replace DynamicGraphAssetMetadata-based behavior with explicit feature metadata native to this IOManager
 
 
 class FilesystemADLS2IOManager(UPathIOManager):
@@ -123,7 +126,7 @@ class FilesystemADLS2IOManager(UPathIOManager):
     @staticmethod
     def _expand_and_combine(
         real_keys: list[str | MultiPartitionKey],
-        graph_dimensions: list[str],
+        synthetic_partition_keys: list[str],
     ) -> list[str]:
         """
         Normalize partition keys to slash-separated path segments and append
@@ -133,11 +136,12 @@ class FilesystemADLS2IOManager(UPathIOManager):
         so the pipe-separated string is already in the correct order — we
         just replace the delimiter.
         """
+
         def normalize(key: str) -> str:
             return key.replace(MULTIPARTITION_KEY_DELIMITER, "/")
 
         expanded = [normalize(k) for k in real_keys]
-        dim_suffix = "/".join(graph_dimensions)
+        dim_suffix = "/".join(synthetic_partition_keys)
 
         if expanded and dim_suffix:
             return [f"{key}/{dim_suffix}" for key in expanded]
@@ -149,7 +153,7 @@ class FilesystemADLS2IOManager(UPathIOManager):
     @staticmethod
     def _patch_context(
         context: InputContext | OutputContext,
-        dga: "DynamicGraphAssetMetadata",
+        meta: ADLS2FilesystemIOManagerMetadata,
     ):
         """
         Monkey-patch context class properties so the parent UPathIOManager
@@ -158,47 +162,77 @@ class FilesystemADLS2IOManager(UPathIOManager):
         Patching at the class level is required because Dagster context
         properties are defined as class-level descriptors.
         """
-        synthetic_keys = FilesystemADLS2IOManager._expand_and_combine(
-            real_keys=dga.asset_partition_keys,
-            graph_dimensions=dga.graph_dimensions,
-        )
-        has_partitions = bool(synthetic_keys)
+        if meta.synthetic_partition_keys:
+            real_keys = (
+                context.asset_partition_keys
+                if context.has_asset_partitions
+                else meta.asset_partition_keys or []
+            )
+            synthetic_keys = FilesystemADLS2IOManager._expand_and_combine(
+                real_keys=real_keys,
+                synthetic_partition_keys=meta.synthetic_partition_keys,
+            )
+            has_partitions = bool(synthetic_keys)
 
-        context.__class__.asset_partition_keys = property(lambda self: synthetic_keys)
-        context.__class__.has_asset_partitions = property(lambda self: has_partitions)
+            context.__class__.asset_partition_keys = property(
+                lambda self: synthetic_keys
+            )
+            context.__class__.has_asset_partitions = property(
+                lambda self: has_partitions
+            )
+            log.debug(
+                f"Patched context: synthetic_partition_keys={synthetic_keys}"
+            )
 
-        if dga.asset_key:
-            context.__class__.asset_key = property(lambda self: AssetKey(dga.asset_key))
+        if meta.asset_key_path:
+            context.__class__.asset_key = property(
+                lambda self: AssetKey(meta.asset_key_path)
+            )
             context.__class__.has_asset_key = property(lambda self: True)
-
-        log.debug(
-            f"Patched context: asset_key={dga.asset_key}, "
-            f"synthetic_partition_keys={synthetic_keys}"
-        )
+            log.debug(f"Patched context: asset_key={meta.asset_key_path}")
 
     def handle_output(self, context: OutputContext, obj: Any):
-        """
-        On write: read DGA metadata from output_metadata, patch the context,
-        then delegate to the parent which calls dump_to_path at the right path.
-        """
-        output_metadata = context.output_metadata or {}
-        dga = DynamicGraphAssetMetadata.from_metadata(output_metadata)
+        meta = ADLS2FilesystemIOManagerMetadata.from_metadata(
+            context.output_metadata or {}
+        )
 
-        if dga and not dga.should_return_parent:
-            log.debug(f"handle_output: DGA metadata found → {dga}")
-            self._patch_context(context, dga)
+        output_metadata = context.output_metadata
+        log.debug(f"output_metadata: '{output_metadata}'")
+        meta = ADLS2FilesystemIOManagerMetadata.from_metadata(output_metadata)
+
+        if meta and meta.skip_output:
+            log.info("dump_to_path: skip_output=True, skipping upload")
+            return
+
+        if meta:
+            if meta.skip_output:
+                log.debug(
+                    f"handle_output found output metadata, patching context: {meta}"
+                )
+
+            log.debug(
+                f"handle_output found output metadata, patching context: {meta}"
+            )
+            self._patch_context(context, meta)
         else:
-            log.debug("handle_output: no DGA metadata, using standard behaviour")
+            log.debug("handle_output no metadata found.")
 
         super().handle_output(context, obj)
 
     def load_input(self, context: InputContext) -> Union[Any, dict[str, Any]]:
         input_metadata = context.definition_metadata
         log.debug(f"input_metadata: '{input_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(input_metadata)
-        if dga_metadata:
-            log.debug("@dynamic_graph_asset, returning dummy abfss://")
-            return
+        meta = ADLS2FilesystemIOManagerMetadata.from_metadata(input_metadata)
+
+        if meta:
+            if meta.skip_input:
+                log.debug("load_input: skip_input=True, returning None")
+                return
+
+            # TODO: is this needed?
+            # if meta.synthetic_partition_keys:
+            #     self._patch_context(context, meta)
+
         return super().load_input(context)
 
     # -------------------------------------------------------------------------
@@ -221,14 +255,6 @@ class FilesystemADLS2IOManager(UPathIOManager):
         ``obj`` should be a ``pathlib.Path`` pointing to a local file or directory.
         ``path`` is the ADLS2 destination path as constructed by UPathIOManager.
         """
-        output_metadata = context.output_metadata
-        log.debug(f"output_metadata: '{output_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(output_metadata)
-        if dga_metadata and dga_metadata.should_return_parent:
-            log.info(
-                "@dynamic_graph_asset.should_return_parent==True, ignoring dump_to_path"
-            )
-            return
 
         if not isinstance(obj, Path):
             raise TypeError(
@@ -298,9 +324,6 @@ class FilesystemADLS2IOManager(UPathIOManager):
         """
         adls2_prefix = str(path)
 
-        input_metadata = context.definition_metadata
-        log.debug(f"input_metadata: '{input_metadata}'")
-        dga_metadata = DynamicGraphAssetMetadata.from_metadata(input_metadata)
         # If the downstream asset wants a string, return the ADLS2 URI directly
         # so the asset can use the SDK to selectively download files itself
         ttype = context.dagster_type.typing_type
@@ -338,7 +361,7 @@ class FilesystemADLS2IOManager(UPathIOManager):
         # ------------------------------------------------------------
         # MODE 2: return rich ADLS2 handle
         # ------------------------------------------------------------
-        if self._input_mode == "reference" or dga_metadata:
+        if self._input_mode == "reference":
             return ADLS2Path(
                 _io_manager=self,
                 _path=adls2_prefix,

--- a/src/cfa_dagster/azure_adls2/filesystem_metadata.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_metadata.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
-from typing import Optional, Literal
+from dataclasses import asdict, dataclass
+from typing import Literal, Optional
+
 import dagster as dg
 
 InputMode = Literal["path", "download", "reference"]
@@ -28,21 +29,27 @@ class ADLS2FilesystemIOManagerMetadata:
                     metadata={
                         "adls2_io_manager": {
                             "input_mode": "reference",
-                            "synthetic_partitions": ["nodeA", "nodeB"],
+                            "synthetic_partition_keys": ["nodeA", "nodeB"],
                         }
                     }
                 )
             }
         )
     """
+
     skip_input: bool = False
     skip_output: bool = False
-    input_mode: Optional[InputMode] = None  # overrides IOManager-level input_mode if set
-    synthetic_partitions: list[str] = field(default_factory=list)
-    asset_key: Optional[str] = None
+    input_mode: Optional[InputMode] = (
+        None  # overrides IOManager-level input_mode if set
+    )
+    synthetic_partition_keys: list[str] = ([],)
+    asset_partition_keys: Optional[list] = None
+    asset_key_path: Optional[list[str]] = None
 
     @classmethod
-    def from_metadata(cls, metadata: dict) -> Optional["ADLS2FilesystemIOManagerMetadata"]:
+    def from_metadata(
+        cls, metadata: dict
+    ) -> Optional["ADLS2FilesystemIOManagerMetadata"]:
         raw = metadata.get(METADATA_KEY)
         if raw is None:
             return None
@@ -56,6 +63,10 @@ class ADLS2FilesystemIOManagerMetadata:
             skip_input=raw.get("skip_input", False),
             skip_output=raw.get("skip_output", False),
             input_mode=raw.get("input_mode", None),
-            asset_key=raw.get("asset_key", None),
-            synthetic_partitions=raw.get("synthetic_partitions", []),
+            asset_key_path=raw.get("asset_key_path", None),
+            asset_partition_keys=raw.get("asset_partition_keys", None),
+            synthetic_partition_keys=raw.get("synthetic_partition_keys", []),
         )
+
+    def to_dict(self) -> dict:
+        return {METADATA_KEY: asdict(self)}

--- a/src/cfa_dagster/azure_adls2/filesystem_metadata.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_metadata.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass, field
+from typing import Optional, Literal
+import dagster as dg
+
+InputMode = Literal["path", "download", "reference"]
+
+METADATA_KEY = "adls2_fs_io_manager"
+
+
+@dataclass
+class ADLS2FilesystemIOManagerMetadata:
+    """
+    Per-asset metadata contract for FilesystemADLS2IOManager.
+
+    Set via input/output metadata to override IOManager behavior for a specific asset:
+
+        @asset(
+            metadata={
+                "adls2_io_manager": {
+                    "skip_output": True,
+                }
+            }
+        )
+
+        @asset(
+            ins={
+                "upstream": AssetIn(
+                    metadata={
+                        "adls2_io_manager": {
+                            "input_mode": "reference",
+                            "synthetic_partitions": ["nodeA", "nodeB"],
+                        }
+                    }
+                )
+            }
+        )
+    """
+    skip_input: bool = False
+    skip_output: bool = False
+    input_mode: Optional[InputMode] = None  # overrides IOManager-level input_mode if set
+    synthetic_partitions: list[str] = field(default_factory=list)
+    asset_key: Optional[str] = None
+
+    @classmethod
+    def from_metadata(cls, metadata: dict) -> Optional["ADLS2FilesystemIOManagerMetadata"]:
+        raw = metadata.get(METADATA_KEY)
+        if raw is None:
+            return None
+        if isinstance(raw, dg.MetadataValue):
+            raw = raw.value
+        if not isinstance(raw, dict):
+            raise TypeError(
+                f"Expected 'adls2_io_manager' metadata to be a dict, got {type(raw)}"
+            )
+        return cls(
+            skip_input=raw.get("skip_input", False),
+            skip_output=raw.get("skip_output", False),
+            input_mode=raw.get("input_mode", None),
+            asset_key=raw.get("asset_key", None),
+            synthetic_partitions=raw.get("synthetic_partitions", []),
+        )

--- a/src/cfa_dagster/azure_adls2/filesystem_path.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_path.py
@@ -1,0 +1,113 @@
+from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from pathlib import Path
+from azure.storage.filedatalake import (
+    DataLakeDirectoryClient,
+    DataLakeFileClient,
+    FileSystemClient,
+)
+
+if TYPE_CHECKING:
+    from .filesystem_io_manager import FilesystemADLS2IOManager
+
+
+@dataclass(frozen=True)
+class ADLS2Path:
+    """
+    Represents a path in ADLS2.
+
+    This object provides authenticated access to the underlying Azure SDK
+    clients while also exposing convenience methods for common operations.
+
+    Users can always drop down to the Azure SDK if they need functionality
+    beyond the convenience methods.
+
+    Examples
+    --------
+
+    Download entire asset:
+
+        local_dir = data.download()
+
+    Download only a subfolder:
+
+        parquet_dir = data.download("parquet")
+
+    Access Azure SDK directly:
+
+        directory_client = data.get_directory_client()
+
+        for item in directory_client.get_paths():
+            ...
+    """
+
+    _io_manager: "FilesystemADLS2IOManager"
+    _path: str
+    local_dir: Path
+
+    @property
+    def uri(self) -> str:
+        return self._io_manager._uri_for_prefix(self._path)
+
+    @property
+    def file_system_client(self) -> FileSystemClient:
+        return self._io_manager._file_system_client
+
+    def get_directory_client(self) -> DataLakeDirectoryClient:
+        return self.file_system_client.get_directory_client(self._path)
+
+    def get_file_client(self) -> DataLakeFileClient:
+        return self.file_system_client.get_file_client(self._path)
+
+    def list(self, recursive: bool = False):
+        """
+        List paths beneath this ADLS location.
+
+        Returns Azure SDK PathProperties objects.
+        """
+        return self.file_system_client.get_paths(
+            path=self._path,
+            recursive=recursive,
+        )
+
+    def download(
+        self,
+        relative_path: str | None = None,
+        local_dir: Path | None = None,
+    ) -> Path:
+        """
+        Download this path or a subpath.
+
+        Examples
+        --------
+
+        Download entire asset:
+
+            data.download()
+
+        Download parquet subdirectory:
+
+            data.download("parquet")
+
+        Download nested path:
+
+            data.download("parquet/2026/01")
+        """
+
+        target_path = self._path
+
+        if relative_path:
+            target_path = (Path(target_path) / relative_path).as_posix()
+            if not local_dir:
+                local_dir = self.local_dir / relative_path
+
+        return self._io_manager.download_prefix(
+            adls2_prefix=target_path,
+            local_dir=local_dir,
+        )
+
+    def __str__(self) -> str:
+        return self.uri
+
+    def __repr__(self) -> str:
+        return f"ADLS2Path(uri='{self.uri}')"

--- a/src/cfa_dagster/azure_adls2/filesystem_path.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_path.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 from azure.storage.filedatalake import (
     DataLakeDirectoryClient,
     DataLakeFileClient,

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._utils.warnings import BetaWarning
 from typing_extensions import Unpack
 
+from .azure_adls2.filesystem_metadata import ADLS2FilesystemIOManagerMetadata
 from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
 from .execution.utils import ExecutionConfig, SelectorConfig
 
@@ -266,6 +267,16 @@ class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
         context._mapping_key_names = mapping_key_names
         context._mapping_key = None
         return context  # type: ignore[return-value]
+
+
+def unpack_output(output) -> tuple[Any, dict]:
+    if isinstance(output, dg.Output):
+        user_value = output.value
+        user_metadata = output.metadata or {}
+    else:
+        user_value = output
+        user_metadata = {}
+    return user_value, user_metadata
 
 
 def add_metadata_to_output(
@@ -701,16 +712,35 @@ def dynamic_graph_asset(
                 result = next(result)
             log.debug(f"compute result: '{result}'")
             if is_annotated_sequence or is_first_dimension:
-                yield add_metadata_to_output(
-                    result=result,
-                    asset_key=final_asset_key,
-                    graph_dimensions=list(
-                        dynamic_context.graph_dimension.values()
-                    ),
-                    asset_partition_keys=dynamic_context.partition_keys
-                    if dynamic_context.has_partition_key
-                    else [],
-                )
+                result, metadata = unpack_output(result)
+
+                # Merge our graph_dimensions metadata
+                merged_metadata = {
+                    **dict(metadata),
+                    **ADLS2FilesystemIOManagerMetadata(
+                        asset_key_path=final_asset_key.path,
+                        asset_partition_keys=dynamic_context.partition_keys
+                        if dynamic_context.has_partition_key
+                        else [],
+                        synthetic_partition_keys=list(
+                            dynamic_context.graph_dimension.values()
+                        ),
+                    ).to_dict(),
+                }
+                log.debug(f"merged_metadata: '{merged_metadata}'")
+
+                yield dg.Output(value=result, metadata=merged_metadata)
+
+                # yield add_metadata_to_output(
+                #     result=result,
+                #     asset_key=final_asset_key,
+                #     graph_dimensions=list(
+                #         dynamic_context.graph_dimension.values()
+                #     ),
+                #     asset_partition_keys=dynamic_context.partition_keys
+                #     if dynamic_context.has_partition_key
+                #     else [],
+                # )
 
         # -- output op to return results --
         @dg.op(
@@ -723,9 +753,11 @@ def dynamic_graph_asset(
                             if io_manager_key
                             else {}
                         ),
-                        metadata=DynamicGraphAssetMetadata(
-                            asset_key=final_asset_key.path,
-                        ).to_metadata(),
+                        metadata=(
+                            ADLS2FilesystemIOManagerMetadata(
+                                skip_input=True
+                            ).to_dict()
+                        ),
                     )
                     if does_return_value
                     else dg.In(dg.Nothing)
@@ -754,15 +786,32 @@ def dynamic_graph_asset(
                 # handle yielded Output
                 if isinstance(result, GeneratorType):
                     result = next(result)
-                return add_metadata_to_output(
-                    result=result if is_annotated_sequence else result[0],
-                    asset_key=final_asset_key,
-                    should_return_parent=True,
-                    graph_dimensions=graph_dimensions,
-                    asset_partition_keys=context.partition_keys
-                    if context.has_partition_key
-                    else [],
-                )
+
+                # handle sequences
+                result = (result if is_annotated_sequence else result[0],)
+
+                result, metadata = unpack_output(result)
+
+                # Merge our graph_dimensions metadata
+                merged_metadata = {
+                    **dict(metadata),
+                    **ADLS2FilesystemIOManagerMetadata(
+                        skip_output=True
+                    ).to_dict(),
+                }
+                log.debug(f"merged_metadata: '{merged_metadata}'")
+
+                # Yield a new Output object with merged metadata
+                yield dg.Output(value=result, metadata=merged_metadata)
+                # return add_metadata_to_output(
+                #     result=result if is_annotated_sequence else result[0],
+                #     asset_key=final_asset_key,
+                #     should_return_parent=True,
+                #     graph_dimensions=graph_dimensions,
+                #     asset_partition_keys=context.partition_keys
+                #     if context.has_partition_key
+                #     else [],
+                # )
 
         # -- config mapping --
         @dg.config_mapping(config_schema=config_cls.to_config_schema())


### PR DESCRIPTION
Closes #113

This PR fixes ADLS2FilesystemIOManager outputs when using a multi-partitioned @dynamic_graph_asset. Previously, outputs were getting sent to a path like `abfss://cfadagster/files/<asset_name>/partition1|partition2` instead of `abfss://cfadagster/files/<asset_name>/partition1/partition2`. 
The approach to fixing this was to patch the IOManager `context` instead of overriding default UPathIOManager internals.
While making this change, I also updated the IOManager to provide its own metadata for defining input/output behavior instead of reading DynamicGraphAssetMetadata. This allows the IOManager to own its own behavior and makes it easier to understand the intention at each step of the @dynamic_graph_asset