### PR TITLE
Breaking Feature: Use dg.ConfigurableResource for @dynamic_graph_asset graph dimensions instead of dg.Config

### DIFF
--- a/examples/dagster_defs.py
+++ b/examples/dagster_defs.py
@@ -20,7 +20,7 @@ from dagster_azure.blob import (
 # ruff: noqa: F401
 from cfa_dagster import (
     ADLS2PickleIOManager,
-    DynamicGraphAssetExecutionContext,
+    GraphDimension,
     ExecutionConfig,
     SelectorConfig,
     azure_batch_executor,
@@ -52,7 +52,6 @@ workdir = "/app"
 # this is the default run config that launches the job in your local shell
 # and executes each step in a separate system process
 default_config = ExecutionConfig(
-    launcher=SelectorConfig(class_name=dg.DefaultRunLauncher.__name__),
     executor=SelectorConfig(class_name=dg.multiprocess_executor.__name__),
 )
 
@@ -96,8 +95,7 @@ azure_caj_config = ExecutionConfig(
     )
 )
 
-# configuring a run launcher to launch each run in an Azure Container App Job
-# and configuring an executor to run each workflow steps in a new Azure Batch
+# configuring an executor to run each workflow steps in a new Azure Batch
 # task for maximum scale
 # add this to a job or the Definitions class to use it
 azure_batch_config = ExecutionConfig(
@@ -167,53 +165,53 @@ def basic_r_asset(basic_blob_asset):
     )
 
 
-class ParallelRAssetConfig(dg.Config):
-    disease: list[str] = ["COVID", "FLU", "RSV"]
+class ParallelRAssetConfig(dg.ConfigurableResource):
+    disease: GraphDimension[str] = GraphDimension(["COVID", "FLU", "RSV"])
 
 
 @dynamic_graph_asset(
-    graph_dimensions=["disease"],
     description="A parallel asset that runs R code for different diseases",
 )
 def parallel_r_asset(
-    context: DynamicGraphAssetExecutionContext,
-    config: ParallelRAssetConfig,
+    context: dg.OpExecutionContext,
+    parallel_r_asset_config: ParallelRAssetConfig,
 ):
-    disease = context.graph_dimension["disease"]
-    subprocess.run(f"Rscript hello.R {disease}", shell=True, check=True)
+    disease = parallel_r_asset_config.disease.current_value
+    context.log.info(f"Running for disease: {disease}")
+    subprocess.run(["Rscript", "hello.R", disease], check=True)
 
 
 # ------------------------------------------------
 # Jobs - tasks that don't produce tracked artifacts
 # ------------------------------------------------
 
+# only expose this job when running locally
+if not is_production():
+    @dg.op
+    def build_image(context: dg.OpExecutionContext, should_push: bool):
+        cmd = f"docker build -t {image} ."
 
-@dg.op
-def build_image(context: dg.OpExecutionContext, should_push: bool):
-    cmd = f"docker build -t {image} ."
+        if should_push:
+            subprocess.run(
+                f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
+                check=True,
+                shell=True,
+            )
+            cmd += " --push"
 
-    if should_push:
-        subprocess.run(
-            f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
-            check=True,
-            shell=True,
-        )
-        cmd += " --push"
+        context.log.debug(f"Running {cmd}")
+        subprocess.run(cmd, check=True, shell=True)
 
-    context.log.debug(f"Running {cmd}")
-    subprocess.run(cmd, check=True, shell=True)
-
-
-@dg.job(
-    config=dg.RunConfig(
-        ops={"build_image": {"inputs": {"should_push": False}}},
-        # configure this job to run on your computer
-        execution=default_config.to_run_config(),
-    ),
-    executor_def=dynamic_executor(),
-)
-def build_image_job():
-    build_image()
+    @dg.job(
+        config=dg.RunConfig(
+            ops={"build_image": {"inputs": {"should_push": False}}},
+            # configure this job to run on your computer
+            execution=default_config.to_run_config(),
+        ),
+        executor_def=dynamic_executor(),
+    )
+    def build_image_job():
+        build_image()
 
 
 # --------------------------------------------
@@ -244,6 +242,7 @@ defs = dg.Definitions(
             account_url=f"{storage_account}.blob.core.windows.net",
             credential=AzureBlobStorageDefaultCredential(),
         ),
+        "parallel_r_asset_config": ParallelRAssetConfig(),
     },
     executor=dynamic_executor(
         # try switching to Azure compute after pushing your image

--- a/examples/dagster_defs.py
+++ b/examples/dagster_defs.py
@@ -20,8 +20,8 @@ from dagster_azure.blob import (
 # ruff: noqa: F401
 from cfa_dagster import (
     ADLS2PickleIOManager,
-    GraphDimension,
     ExecutionConfig,
+    GraphDimension,
     SelectorConfig,
     azure_batch_executor,
     azure_container_app_job_executor,
@@ -187,6 +187,7 @@ def parallel_r_asset(
 
 # only expose this job when running locally
 if not is_production():
+
     @dg.op
     def build_image(context: dg.OpExecutionContext, should_push: bool):
         cmd = f"docker build -t {image} ."

--- a/examples/minimal_dagster_defs.py
+++ b/examples/minimal_dagster_defs.py
@@ -10,8 +10,8 @@
 import dagster as dg
 
 from cfa_dagster import (
-    collect_definitions,
     GraphDimension,
+    collect_definitions,
     dynamic_graph_asset,
     start_dev_env,
 )
@@ -25,9 +25,7 @@ class MyAssetConfig(dg.ConfigurableResource):
 
 
 @dynamic_graph_asset
-def my_asset(
-    context: dg.OpExecutionContext, my_asset_config: MyAssetConfig
-):
+def my_asset(context: dg.OpExecutionContext, my_asset_config: MyAssetConfig):
     disease = my_asset_config.disease.current_value
     context.log.info(f"Watch out for: '{disease}'")
 
@@ -36,8 +34,5 @@ collected_defs = collect_definitions(globals())
 
 # Create Definitions object
 defs = dg.Definitions(
-        **collected_defs,
-        resources={
-            "my_asset_config": MyAssetConfig()
-            }
-        )
+    **collected_defs, resources={"my_asset_config": MyAssetConfig()}
+)

--- a/examples/minimal_dagster_defs.py
+++ b/examples/minimal_dagster_defs.py
@@ -7,15 +7,11 @@
 # ]
 # ///
 
-# from time import sleep
-from typing import List
-
 import dagster as dg
 
-# ruff: noqa: F401
 from cfa_dagster import (
-    DynamicGraphAssetExecutionContext,
     collect_definitions,
+    GraphDimension,
     dynamic_graph_asset,
     start_dev_env,
 )
@@ -24,21 +20,24 @@ from cfa_dagster import (
 start_dev_env(__name__)
 
 
-class MyAssetConfig(dg.Config):
-    disease: List[str] = ["covid", "flu", "rsv"]
+class MyAssetConfig(dg.ConfigurableResource):
+    disease: GraphDimension[str] = GraphDimension(["covid", "flu", "rsv"])
 
 
-@dynamic_graph_asset(
-    graph_dimensions=["disease"],
-)
+@dynamic_graph_asset
 def my_asset(
-    context: DynamicGraphAssetExecutionContext, config: MyAssetConfig
+    context: dg.OpExecutionContext, my_asset_config: MyAssetConfig
 ):
-    disease = context.graph_dimension["disease"]
+    disease = my_asset_config.disease.current_value
     context.log.info(f"Watch out for: '{disease}'")
 
 
 collected_defs = collect_definitions(globals())
 
 # Create Definitions object
-defs = dg.Definitions(**collected_defs)
+defs = dg.Definitions(
+        **collected_defs,
+        resources={
+            "my_asset_config": MyAssetConfig()
+            }
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfa-dagster"
-version = "1.2.1"
+version = "1.3.0"
 description = "CFA libraries for Dagster"
 readme = "README.md"
 authors = [

--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -13,8 +13,8 @@ from .azure_container_app_job.launcher import AzureContainerAppJobRunLauncher
 from .azure_keyvault import AzureKeyVaultResource
 from .docker.executor import docker_executor
 from .dynamic_graph_asset import (
-    dynamic_graph_asset,
     GraphDimension,
+    dynamic_graph_asset,
 )
 from .execution import (
     CFAQueuedRunCoordinator,

--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -13,7 +13,6 @@ from .azure_container_app_job.launcher import AzureContainerAppJobRunLauncher
 from .azure_keyvault import AzureKeyVaultResource
 from .docker.executor import docker_executor
 from .dynamic_graph_asset import (
-    DynamicGraphAssetExecutionContext,
     dynamic_graph_asset,
     GraphDimension,
 )

--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -15,6 +15,7 @@ from .docker.executor import docker_executor
 from .dynamic_graph_asset import (
     DynamicGraphAssetExecutionContext,
     dynamic_graph_asset,
+    GraphDimension,
 )
 from .execution import (
     CFAQueuedRunCoordinator,

--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -14,6 +14,7 @@ from .azure_keyvault import AzureKeyVaultResource
 from .docker.executor import docker_executor
 from .dynamic_graph_asset import (
     GraphDimension,
+    GraphDimensionExclusion,
     dynamic_graph_asset,
 )
 from .execution import (

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -6,21 +6,23 @@ import re
 import sys
 import textwrap
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass
 from types import GeneratorType
 from typing import (
     AbstractSet,
     Any,
-    cast,
+    Callable,
     Generic,
+    Literal,
     Mapping,
     Optional,
     TypedDict,
     TypeVar,
     Union,
+    cast,
     get_origin,
     get_type_hints,
+    overload,
 )
 from typing import Sequence as TypeSequence
 
@@ -31,12 +33,12 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._utils.warnings import BetaWarning
+from pydantic import PrivateAttr
 from typing_extensions import Unpack
 
 from .azure_adls2.filesystem_metadata import ADLS2FilesystemIOManagerMetadata
 from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
 from .execution.utils import ExecutionConfig, SelectorConfig
-from pydantic import PrivateAttr
 
 log = logging.getLogger(__name__)
 
@@ -100,36 +102,6 @@ class GraphDimension(dg.Config, Generic[T]):
         return self._current_value
 
 
-def _get_return_info(asset_name, hints, fn) -> tuple[bool, bool]:
-    """ 
-    Returns a tuple to indicate whether the fn returns a value and if it
-    is annotated with a Sequence return type
-    """
-    return_type = hints.get("return")
-    log.debug(f"return_type: '{return_type}'")
-    origin = get_origin(return_type) or return_type
-
-    is_annotated_sequence = (
-        isinstance(origin, type)
-        and issubclass(origin, Sequence)
-        and not issubclass(origin, (str, bytes))
-    )
-    log.debug(f"is_annotated_sequence: '{is_annotated_sequence}'")
-
-    does_return_value = inspect.isgeneratorfunction(
-        fn
-    ) or _has_return_value(fn)
-    log.debug(f"does_return_value: '{does_return_value}'")
-
-    if does_return_value and return_type is None:
-        raise ValueError(
-            f"@dynamic_graph_asset '{asset_name}': decorated function must "
-            "have a return type annotation when returning a value e.g. -> str. Use list[some_type] "
-            "to return the value from each graph_dimension."
-        )
-    return does_return_value, is_annotated_sequence
-
-
 def _get_resource_params(hints) -> dict[str, type]:
     resource_params: dict[str, type] = {
         name: hint
@@ -186,14 +158,18 @@ def _get_config_cls(hints):
         (
             hint
             for hint in hints.values()
-            if inspect.isclass(hint) and issubclass(hint, dg.Config) and not issubclass(hint, dg.ConfigurableResource)
+            if inspect.isclass(hint)
+            and issubclass(hint, dg.Config)
+            and not issubclass(hint, dg.ConfigurableResource)
         ),
         None,
     )
     return config_cls
 
 
-def _get_asset_key(asset_name: str, graph_asset_kwargs: GraphAssetKwargs) -> dg.AssetKey:
+def _get_asset_key(
+    asset_name: str, graph_asset_kwargs: GraphAssetKwargs
+) -> dg.AssetKey:
     base_key = graph_asset_kwargs.get("key") or asset_name
     final_asset_key = base_key
 
@@ -226,10 +202,7 @@ def _is_dimension_annotation(annotation) -> bool:
         None,
     )
 
-    return (
-        metadata is not None
-        and metadata.get("origin") is GraphDimension
-    )
+    return metadata is not None and metadata.get("origin") is GraphDimension
 
 
 def _has_return_value(fn) -> bool:
@@ -352,8 +325,7 @@ def _infer_ins(
     }
     op_ins = {**inferred_ins, **(ins or {})}
     asset_ins = {
-        name: _in_to_asset_in(name, op_in)
-        for name, op_in in op_ins.items()
+        name: _in_to_asset_in(name, op_in) for name, op_in in op_ins.items()
     }
     return op_ins, asset_ins
 
@@ -377,12 +349,30 @@ def _apply_graph_dimensions(
 
 
 # -- Decorator --
+@overload
+def dynamic_graph_asset(
+    fn: Callable[..., Any],
+    /,
+) -> dg.AssetsDefinition: ...
+
+
+@overload
+def dynamic_graph_asset(
+    ins: dict[str, dg.In] | None = None,
+    io_manager_key: str | None = None,
+    retry_policy: dg.RetryPolicy | None = None,
+    output_mode: Literal["first", "all"] = "first",
+    **graph_asset_kwargs: Unpack[GraphAssetKwargs],
+) -> Callable[[Callable[..., Any]], dg.AssetsDefinition]: ...
+
+
 def dynamic_graph_asset(
     ins: dict[str, dg.In] = None,
     io_manager_key: Optional[str] = None,
     retry_policy: Optional[dg.RetryPolicy] = None,
+    output_mode: Literal["first", "all"] = "first",
     **graph_asset_kwargs: Unpack[GraphAssetKwargs],
-):
+) -> dg.AssetsDefinition | Callable[[Callable[..., Any]], dg.AssetsDefinition]:
     """
     Decorator that wires a function into a dynamic graph asset to run steps in parallel based on a provided ConfigurableResource.
     See https://docs.dagster.io/guides/build/ops/dynamic-graphs#using-dynamic-outputs
@@ -396,9 +386,8 @@ def dynamic_graph_asset(
     so original values (including spaces, hyphens, etc.) are recovered exactly in
     the compute op, while safe characters remain human-readable in the Dagster UI.
 
-    Return type annotations are required since they determine the behavior of the output.
-    To return a single Output, use a simple type like str, int, bool.
-    To return an Output from each graph dimension, use a 'list[some_type]'.
+    Return type annotations are required for functions that return a value.
+    Use ``output_mode`` to control whether the output is emitted from a single dimension or collected from all dimensions.
     This is especially powerful with the ADLS2FilesystemIOManager since you can upload a file or directory for each graph dimension and return the parent directory as the final output.
     Downstream assets using the ADLS2FilesystemIOManager will download the structured directory automatically.
 
@@ -455,6 +444,11 @@ def dynamic_graph_asset(
             general, versions should be set only for code that deterministically produces the same
             output when given the same inputs.
         retry_policy (Optional[RetryPolicy]): The retry policy for this asset.
+        output_mode (Literal["first", "all"]): Controls whether the output is emitted from a
+            single dimension (``"first"``, the default) or collected across all dimensions
+            (``"all"``). Use ``"all"`` when each dimension should independently produce an
+            output, e.g. with the ADLS2FilesystemIOManager where each dimension uploads
+            files. Defaults to ``"first"``.
         key (Optional[CoeercibleToAssetKey]): The key for this asset. If provided, cannot specify key_prefix or name.
 
 
@@ -479,7 +473,7 @@ def dynamic_graph_asset(
             partitions_def=daily_partitions,
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> str:
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=f"staging/{context.partition_key}",
@@ -495,7 +489,7 @@ def dynamic_graph_asset(
             io_manager_key="ADLS2PickleIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> list[str]:
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             result = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=result,
@@ -515,7 +509,7 @@ def dynamic_graph_asset(
             io_manager_key="ADLS2FilesystemIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> list[Path]:
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             output_path = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=output_path,
@@ -538,13 +532,24 @@ def dynamic_graph_asset(
 
     """
 
+    if callable(ins):
+        _fn = ins
+        ins = None
+    else:
+        _fn = None
+
     def decorator(fn):
         asset_name = fn.__name__
 
         hints = get_type_hints(fn, globalns=vars(sys.modules[fn.__module__]))
         sig = inspect.signature(fn)
 
-        does_return_value, is_annotated_sequence = _get_return_info(asset_name, hints, fn)
+        does_return_value = inspect.isgeneratorfunction(
+            fn
+        ) or _has_return_value(fn)
+        log.debug(f"does_return_value: '{does_return_value}'")
+
+        should_return_all = output_mode == "all"
 
         # -- Locate the Config parameter --
         config_cls = _get_config_cls(hints)
@@ -572,7 +577,9 @@ def dynamic_graph_asset(
         log.debug(f"required_resource_keys: '{required_resource_keys}'")
 
         # -- Locate resources containing GraphDimension fields --
-        dimension_resource_info = _get_dimension_resource_info(asset_name, resource_params)
+        dimension_resource_info = _get_dimension_resource_info(
+            asset_name, resource_params
+        )
 
         op_ins, asset_ins = _infer_ins(sig, required_resource_keys, ins)
         log.debug(f"op_ins: '{op_ins}'")
@@ -605,7 +612,10 @@ def dynamic_graph_asset(
                     else {}
                 ),
             },
-            required_resource_keys=[INTERNAL_CONFIG_IO_MANAGER_KEY, dimension_resource_info.param_name],
+            required_resource_keys=[
+                INTERNAL_CONFIG_IO_MANAGER_KEY,
+                dimension_resource_info.param_name,
+            ],
             tags=in_process_config.to_run_tags(),
         )
         def gen_config(context, **kwargs):
@@ -638,10 +648,10 @@ def dynamic_graph_asset(
                 mapping_key = _encode_mapping_key(combo)
 
                 yield dg.DynamicOutput(
-                        value=None,
-                        mapping_key=mapping_key,
-                        output_name="dga_internal_fanout",
-                        )
+                    value=None,
+                    mapping_key=mapping_key,
+                    output_name="dga_internal_fanout",
+                )
 
         # -- compute op to run decorated function body --
         @dg.op(
@@ -679,12 +689,14 @@ def dynamic_graph_asset(
             + list(graph_asset_kwargs.get("resource_defs", {}).keys())
             + [INTERNAL_CONFIG_IO_MANAGER_KEY],
             retry_policy=retry_policy,
-            config_schema=config_cls.to_config_schema() if config_cls else None,
+            config_schema=config_cls.to_config_schema()
+            if config_cls
+            else None,
         )
         def compute(
-                context: dg.OpExecutionContext,
-                **kwargs,
-                ):
+            context: dg.OpExecutionContext,
+            **kwargs,
+        ):
             upstream_kwargs = {
                 k: v for k, v in kwargs.items() if k in decorated_fn_kwargs
             }
@@ -699,20 +711,27 @@ def dynamic_graph_asset(
             # decode graph_dimensions from mapping_key
             mapping_key = cast(str, context.get_mapping_key())
             decoded = _decode_mapping_key(mapping_key)
-            graph_dimensions = dict(zip(dimension_resource_info.dimension_fields, decoded))
+            graph_dimensions = dict(
+                zip(dimension_resource_info.dimension_fields, decoded)
+            )
             log.debug(f"graph_dimensions: '{graph_dimensions}'")
 
-            dimension_resource = _apply_graph_dimensions(context, dimension_resource_info, graph_dimensions)
+            dimension_resource = _apply_graph_dimensions(
+                context, dimension_resource_info, graph_dimensions
+            )
 
             is_first_dimension = all(
-                graph_dimensions[field] == getattr(dimension_resource, field).values[0]
+                graph_dimensions[field]
+                == getattr(dimension_resource, field).values[0]
                 for field in dimension_resource_info.dimension_fields
             )
 
             log.debug(f"is_first_dimension: '{is_first_dimension}'")
 
             if config_cls is not None:
-                dga_internal_shared_config = kwargs.get("dga_internal_shared_config")
+                dga_internal_shared_config = kwargs.get(
+                    "dga_internal_shared_config"
+                )
                 config = config_cls(**dga_internal_shared_config)
                 log.debug(f"config: '{config}'")
                 result = fn(
@@ -731,7 +750,7 @@ def dynamic_graph_asset(
             if isinstance(result, GeneratorType):
                 result = next(result)
             log.debug(f"compute result: '{result}'")
-            if is_annotated_sequence or is_first_dimension:
+            if should_return_all or is_first_dimension:
                 result, metadata = unpack_output(result)
 
                 # Merge our graph_dimensions metadata
@@ -772,7 +791,9 @@ def dynamic_graph_asset(
                     else dg.In(dg.Nothing)
                 ),
             },
-            config_schema=config_cls.to_config_schema() if config_cls else None,
+            config_schema=config_cls.to_config_schema()
+            if config_cls
+            else None,
             **(
                 {
                     "out": dg.Out(
@@ -797,7 +818,7 @@ def dynamic_graph_asset(
                     result = next(result)
 
                 # handle sequences
-                result = (result if is_annotated_sequence else result[0],)
+                result = (result if should_return_all else result[0],)
 
                 result, metadata = unpack_output(result)
 
@@ -815,6 +836,7 @@ def dynamic_graph_asset(
 
         # -- config mapping --
         if config_cls is not None:
+
             @dg.config_mapping(config_schema=config_cls.to_config_schema())
             def _config_mapping(config):
                 # initialize the config class to ensure any default_factories run
@@ -858,14 +880,17 @@ def dynamic_graph_asset(
                 gen_result = gen_config(**ins_kwargs)
 
                 if config_cls is not None:
-                    dga_internal_fanout, dga_internal_shared_config = gen_result
+                    dga_internal_fanout, dga_internal_shared_config = (
+                        gen_result
+                    )
                 else:
                     dga_internal_fanout = gen_result
                     dga_internal_shared_config = None
 
                 # Map fanout while passing shared config to every isolated compute worker
                 res = dga_internal_fanout.map(
-                    lambda nothing, _shared=dga_internal_shared_config: compute(
+                    lambda nothing,
+                    _shared=dga_internal_shared_config: compute(
                         _=nothing,
                         **(
                             {"dga_internal_shared_config": _shared}
@@ -879,4 +904,6 @@ def dynamic_graph_asset(
 
             return _asset
 
+    if _fn is not None:
+        return decorator(_fn)
     return decorator

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -7,10 +7,12 @@ import sys
 import textwrap
 import warnings
 from collections.abc import Sequence
+from dataclasses import dataclass
 from types import GeneratorType
 from typing import (
     AbstractSet,
     Any,
+    cast,
     Generic,
     List,
     Mapping,
@@ -74,6 +76,11 @@ class GraphAssetKwargs(TypedDict, total=False):
     kinds: Optional[AbstractSet[str]] = (None,)
 
 
+@dataclass
+class DimensionResourceInfo:
+    param_name: str
+    resource_cls: type
+    dimension_fields: list[str]
 
 
 T = TypeVar("T", default=str)
@@ -93,47 +100,44 @@ class GraphDimension(dg.Config, Generic[T]):
     def current_value(self) -> Optional[T]:
         return self._current_value
 
-def _get_dimension_resources(asset_name, resource_params: dict) -> dict[str, type]:
-    # -- Locate resources containing GraphDimension fields --
-    dimension_resources: dict[str, type] = {}
+
+def _get_dimension_resources(
+    asset_name: str, resource_params: dict[str, type]
+) -> DimensionResourceInfo:
+    dimension_info: DimensionResourceInfo | None = None
 
     for param_name, resource_cls in resource_params.items():
         resource_hints = get_type_hints(resource_cls)
 
-        dimension_fields = []
-
-        for field_name, annotation in resource_hints.items():
-            origin = get_origin(annotation)
-
-            dimension_fields = [
-                field_name
-                for field_name, annotation in resource_hints.items()
-                if _is_dimension_annotation(annotation)
-            ]
+        dimension_fields = [
+            field_name
+            for field_name, annotation in resource_hints.items()
+            if _is_dimension_annotation(annotation)
+        ]
 
         if dimension_fields:
-            dimension_resources[param_name] = {
-                "resource_cls": resource_cls,
-                "dimension_fields": dimension_fields,
-            }
+            if dimension_info is not None:
+                raise ValueError(
+                    f"@dynamic_graph_asset '{asset_name}': "
+                    "Multiple ConfigurableResources contain GraphDimension fields. "
+                    f"Found: '{dimension_info.param_name}' and '{param_name}'. "
+                    "Only one resource may contain GraphDimension fields."
+                )
+            dimension_info = DimensionResourceInfo(
+                param_name=param_name,
+                resource_cls=resource_cls,
+                dimension_fields=dimension_fields,
+            )
 
-    log.debug(f"dimension_resources: {dimension_resources}")
-
-    if len(dimension_resources) == 0:
-        # raise ValueError(
-        log.debug(
+    if dimension_info is None:
+        raise ValueError(
             f"@dynamic_graph_asset '{asset_name}': "
-            "No ConfigurableResource parameter contains GraphDimension fields."
+            "No ConfigurableResource parameter contains GraphDimension fields. "
+            "At least one resource parameter must include fields typed as GraphDimension."
         )
 
-    if len(dimension_resources) > 1:
-        # raise ValueError(
-        log.debug(
-            f"@dynamic_graph_asset '{asset_name}': "
-            "Multiple ConfigurableResources contain GraphDimension fields. "
-            f"Found: {list(dimension_resources.keys())}"
-        )
-    return dimension_resources
+    log.debug(f"dimension_resource_info: {dimension_info}")
+    return dimension_info
 
 
 def _get_asset_key(asset_name: str, graph_asset_kwargs: GraphAssetKwargs) -> dg.AssetKey:
@@ -149,7 +153,10 @@ def _get_asset_key(asset_name: str, graph_asset_kwargs: GraphAssetKwargs) -> dg.
         elif isinstance(key_prefix, list):
             final_asset_key = dg.AssetKey(key_prefix + [base_key])
         else:
-            raise ValueError("key_prefix must be str or list of str")
+            raise ValueError(
+                f"@dynamic_graph_asset '{asset_name}': "
+                "key_prefix must be str or list of str"
+            )
     else:
         final_asset_key = dg.AssetKey(base_key)
     log.debug(f"final_asset_key: '{final_asset_key}'")
@@ -461,7 +468,7 @@ def dynamic_graph_asset(
             io_manager_key="ADLS2FilesystemIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[str]:
+        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[Path]:
             output_path = my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
             return dg.Output(
                 value=output_path,
@@ -559,7 +566,7 @@ def dynamic_graph_asset(
         log.debug(f"required_resource_keys: '{required_resource_keys}'")
 
         # -- Locate resources containing GraphDimension fields --
-        dimension_resources = _get_dimension_resources(asset_name, resource_params)
+        dimension_resource_info = _get_dimension_resources(asset_name, resource_params)
 
         # Infer upstream op ins from all parameters that aren't context or config
         inferred_ins = {
@@ -597,47 +604,39 @@ def dynamic_graph_asset(
             out={
                 # Cheap fanout signal
                 "dga_internal_fanout": dg.DynamicOut(dg.Nothing),
-                # Persisted ONCE and loaded by every mapped compute op
-                "dga_internal_shared_config": dg.Out(
-                    io_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
+                **(
+                    {
+                        # Persisted ONCE and loaded by every mapped compute op
+                        "dga_internal_shared_config": dg.Out(
+                            io_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
+                        ),
+                    }
+                    if config_cls is not None
+                    else {}
                 ),
             },
-            required_resource_keys=[INTERNAL_CONFIG_IO_MANAGER_KEY] + list(dimension_resources.keys()),
+            required_resource_keys=[INTERNAL_CONFIG_IO_MANAGER_KEY, dimension_resource_info.param_name],
             tags=in_process_config.to_run_tags(),
         )
         def gen_config(context, **kwargs):
             log.debug(f"kwargs: '{kwargs}'")
-            config = config_cls(**context.op_config)
+            if config_cls is not None:
+                config = config_cls(**context.op_config)
 
-            # Persist config once for all isolated compute workers
-            yield dg.Output(
-                value=config.model_dump(),
-                output_name="dga_internal_shared_config",
-            )
-
-            # Generate dynamic fanout keys
-            # axes = [getattr(config, field) for field in graph_dimensions]
-            #
-            # for combo in itertools.product(*axes):
-            #     mapping_key = _encode_mapping_key(combo)
-            #     yield dg.DynamicOutput(
-            #         value=None,
-            #         mapping_key=mapping_key,
-            #         output_name="dga_internal_fanout",
-            #     )
-            # There should be exactly one dimension resource
-            dimension_resource_name, dimension_resource_info = next(
-                iter(dimension_resources.items())
-            )
+                # Persist config once for all isolated compute workers
+                yield dg.Output(
+                    value=config.model_dump(),
+                    output_name="dga_internal_shared_config",
+                )
 
             dimension_resource = getattr(
                 context.resources,
-                dimension_resource_name,
+                dimension_resource_info.param_name,
             )
 
             axes = []
 
-            for dimension_field in dimension_resource_info["dimension_fields"]:
+            for dimension_field in dimension_resource_info.dimension_fields:
                 graph_dimension = getattr(
                     dimension_resource,
                     dimension_field,
@@ -659,9 +658,15 @@ def dynamic_graph_asset(
             name=f"{asset_name}__compute",
             ins={
                 "_": dg.In(dg.Nothing),
-                # Shared config loaded from internal IO manager
-                "dga_internal_shared_config": dg.In(
-                    input_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
+                **(
+                    {
+                        # Shared config loaded from internal IO manager
+                        "dga_internal_shared_config": dg.In(
+                            input_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
+                        ),
+                    }
+                    if config_cls is not None
+                    else {}
                 ),
                 **op_ins,
             },
@@ -684,11 +689,10 @@ def dynamic_graph_asset(
             + list(graph_asset_kwargs.get("resource_defs", {}).keys())
             + [INTERNAL_CONFIG_IO_MANAGER_KEY],
             retry_policy=retry_policy,
-            config_schema=config_cls.to_config_schema(),
+            config_schema=config_cls.to_config_schema() if config_cls else None,
         )
         def compute(
                 context: dg.OpExecutionContext,
-                dga_internal_shared_config,
                 **kwargs,
                 ):
             upstream_kwargs = {
@@ -702,86 +706,68 @@ def dynamic_graph_asset(
             }
             log.debug(f"resource_kwargs: {resource_kwargs}")
 
-            config = config_cls(**dga_internal_shared_config)
-            log.debug(f"config: '{config}'")
-
-            # is_first_dimension = all(
-            #     graph_dimension.get(key) == values[0]
-            #     # for key, values in config.dict().items()
-            #     for key, values in config.model_dump().items()
-            #     if key in graph_dimension
-            # )
-            # log.debug(f"is_first_dimension: '{is_first_dimension}'")
-
-            # ----------------------------
-            # Build graph dimension state
-            # from dimension_resources
-            # ----------------------------
-
-            # Expect only one fanout resource (same assumption as config op)
-            dimension_resource_name, dimension_resource_info = next(
-                iter(dimension_resources.items())
-            )
-
-            dimension_resource = getattr(
-                context.resources,
-                dimension_resource_name,
-            )
-
             # Current mapping key (Dagster provides this via dynamic mapping context)
-            # mapping_key = context.dagster_run.tags.get("dagster/map_key", None)
-            mapping_key = context.get_mapping_key()
+            mapping_key = cast(str, context.get_mapping_key())
             log.debug(f"mapping_key: '{mapping_key}'")
 
             # Decode mapping key back into tuple of values
             # (assumes your _encode_mapping_key is reversible)
-            current_combo = _decode_mapping_key(mapping_key)
+            decoded_mapping_key = _decode_mapping_key(mapping_key)
 
-            dimension_fields = dimension_resource_info["dimension_fields"]
+            graph_dimensions = {
+                    field: value
+                    for field, value in zip(
+                        dimension_resource_info.dimension_fields,
+                        decoded_mapping_key
+                        )
+                    }
 
-            graph_dimension = {
-                field: value
-                for field, value in zip(dimension_fields, current_combo)
-            }
-
-            log.debug(f"graph_dimension: '{graph_dimension}'")
+            log.debug(f"graph_dimensions: '{graph_dimensions}'")
 
             # Apply to resource instance for THIS op only
-            for field_name, value in graph_dimension.items():
-                graph_dim_obj = getattr(dimension_resource, field_name)
-
-                graph_dim_obj: GraphDimension = graph_dim_obj
-                graph_dim_obj.set_current_value(value)
-
-            # ----------------------------
-            # Replace DynamicGraphAssetExecutionContext.inject
-            # ----------------------------
-
-            dynamic_context = DynamicGraphAssetExecutionContext.inject(
-                context,
-                graph_dimension,
+            dimension_resource = getattr(
+                context.resources,
+                dimension_resource_info.param_name,
             )
+
+            for field_name, value in graph_dimensions.items():
+                graph_dim_obj = cast(
+                        GraphDimension,
+                        getattr(dimension_resource, field_name)
+                        )
+
+                graph_dim_obj.set_current_value(value)
 
             # ----------------------------
             # Optional: "first dimension" check (now simpler + correct)
             # ----------------------------
 
             is_first_dimension = all(
-                graph_dimension[field] == getattr(
+                graph_dimensions[field] == getattr(
                     dimension_resource, field
                 ).values[0]
-                for field in dimension_fields
+                for field in dimension_resource_info.dimension_fields
             )
 
             log.debug(f"is_first_dimension: '{is_first_dimension}'")
 
-            result = fn(
-                context,
-                # config,
-                **upstream_kwargs,
-                **resource_kwargs,
-            )
-            # handle yielded Output
+            if config_cls is not None:
+                dga_internal_shared_config = kwargs.get("dga_internal_shared_config")
+                config = config_cls(**dga_internal_shared_config)
+                log.debug(f"config: '{config}'")
+                result = fn(
+                    context,
+                    config,
+                    **upstream_kwargs,
+                    **resource_kwargs,
+                )
+            else:
+                result = fn(
+                    context,
+                    **upstream_kwargs,
+                    **resource_kwargs,
+                )
+
             if isinstance(result, GeneratorType):
                 result = next(result)
             log.debug(f"compute result: '{result}'")
@@ -797,7 +783,7 @@ def dynamic_graph_asset(
                         if context.has_partition_key
                         else [],
                         synthetic_partition_keys=list(
-                            context.graph_dimension.values()
+                            graph_dimensions.values()
                         ),
                     ).to_dict(),
                 }
@@ -826,7 +812,7 @@ def dynamic_graph_asset(
                     else dg.In(dg.Nothing)
                 ),
             },
-            config_schema=config_cls.to_config_schema(),
+            config_schema=config_cls.to_config_schema() if config_cls else None,
             **(
                 {
                     "out": dg.Out(
@@ -868,17 +854,18 @@ def dynamic_graph_asset(
                 yield dg.Output(value=result, metadata=merged_metadata)
 
         # -- config mapping --
-        @dg.config_mapping(config_schema=config_cls.to_config_schema())
-        def _config_mapping(config):
-            # initialize the config class to ensure any default_factories run
-            # once and pass the same values to all compute ops
-            resolved = config_cls(**config)
-            resolved_dict = resolved.model_dump()
-            ops = {
-                f"{asset_name}__{op}": {"config": resolved_dict}
-                for op in ("config", "compute", "output")
-            }
-            return ops
+        if config_cls is not None:
+            @dg.config_mapping(config_schema=config_cls.to_config_schema())
+            def _config_mapping(config):
+                # initialize the config class to ensure any default_factories run
+                # once and pass the same values to all compute ops
+                resolved = config_cls(**config)
+                resolved_dict = resolved.model_dump()
+                ops = {
+                    f"{asset_name}__{op}": {"config": resolved_dict}
+                    for op in ("config", "compute", "output")
+                }
+                return ops
 
         # Merge internal IO manager resource with any user resources
         existing_resource_defs = graph_asset_kwargs.get("resource_defs") or {}
@@ -898,7 +885,7 @@ def dynamic_graph_asset(
             # -- graph asset --
             @dg.graph_asset(
                 name=asset_name,
-                config=_config_mapping,
+                **({} if config_cls is None else {"config": _config_mapping}),
                 ins={k: v for k, v in asset_ins.items()},
                 resource_defs=merged_resource_defs,
                 **{
@@ -908,15 +895,23 @@ def dynamic_graph_asset(
                 },
             )
             def _asset(**ins_kwargs):
-                dga_internal_fanout, dga_internal_shared_config = gen_config(
-                    **ins_kwargs
-                )
+                gen_result = gen_config(**ins_kwargs)
+
+                if config_cls is not None:
+                    dga_internal_fanout, dga_internal_shared_config = gen_result
+                else:
+                    dga_internal_fanout = gen_result
+                    dga_internal_shared_config = None
 
                 # Map fanout while passing shared config to every isolated compute worker
                 res = dga_internal_fanout.map(
-                    lambda nothing: compute(
+                    lambda nothing, _shared=dga_internal_shared_config: compute(
                         _=nothing,
-                        dga_internal_shared_config=dga_internal_shared_config,
+                        **(
+                            {"dga_internal_shared_config": _shared}
+                            if _shared is not None
+                            else {}
+                        ),
                         **ins_kwargs,
                     )
                 )

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -22,7 +22,6 @@ from typing import (
     cast,
     get_origin,
     get_type_hints,
-    overload,
 )
 from typing import Sequence as TypeSequence
 
@@ -43,17 +42,6 @@ from .execution.utils import ExecutionConfig, SelectorConfig
 log = logging.getLogger(__name__)
 
 INTERNAL_CONFIG_IO_MANAGER = ADLS2PickleIOManager().get_resource_definition()
-
-# NOTE: Goals for graph_dimension
-# - single-definition of graph_dimension
-# - type-safe access e.g. resource.graph_dimension_property instead of context.graph_dimensions["graph_dimension_property"] so users get an error when accessing an invalid graph_dimension
-# - a 'strict' graph_dimension option using automatically-generated enums e.g. user provides state: list[str] = ["CA", "TX", "NY"] and Launchpad prevents state.WY
-
-# NOTE: Requirements:
-# - GraphDimension type for IDE-level autocomplete
-# - class decorator or subclass for auto-enum behavior UPDATE: not feasible with decorator. Subclass might be overkill
-
-# NOTE: Tradeoffs:
 
 
 class GraphAssetKwargs(TypedDict, total=False):
@@ -349,27 +337,12 @@ def _apply_graph_dimensions(
 
 
 # -- Decorator --
-@overload
 def dynamic_graph_asset(
-    fn: Callable[..., Any],
-    /,
-) -> dg.AssetsDefinition: ...
-
-
-@overload
-def dynamic_graph_asset(
+    fn: Callable[..., Any] | None = None,
+    *,
     ins: dict[str, dg.In] | None = None,
     io_manager_key: str | None = None,
     retry_policy: dg.RetryPolicy | None = None,
-    output_mode: Literal["first", "all"] = "first",
-    **graph_asset_kwargs: Unpack[GraphAssetKwargs],
-) -> Callable[[Callable[..., Any]], dg.AssetsDefinition]: ...
-
-
-def dynamic_graph_asset(
-    ins: dict[str, dg.In] = None,
-    io_manager_key: Optional[str] = None,
-    retry_policy: Optional[dg.RetryPolicy] = None,
     output_mode: Literal["first", "all"] = "first",
     **graph_asset_kwargs: Unpack[GraphAssetKwargs],
 ) -> dg.AssetsDefinition | Callable[[Callable[..., Any]], dg.AssetsDefinition]:
@@ -386,7 +359,6 @@ def dynamic_graph_asset(
     so original values (including spaces, hyphens, etc.) are recovered exactly in
     the compute op, while safe characters remain human-readable in the Dagster UI.
 
-    Return type annotations are required for functions that return a value.
     Use ``output_mode`` to control whether the output is emitted from a single dimension or collected from all dimensions.
     This is especially powerful with the ADLS2FilesystemIOManager since you can upload a file or directory for each graph dimension and return the parent directory as the final output.
     Downstream assets using the ADLS2FilesystemIOManager will download the structured directory automatically.
@@ -472,6 +444,7 @@ def dynamic_graph_asset(
         @dynamic_graph_asset(
             partitions_def=daily_partitions,
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
+            output_mode="first",
         )
         def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
@@ -483,11 +456,11 @@ def dynamic_graph_asset(
 
         Aggregated value from each graph dimension:
 
-
         @dynamic_graph_asset(
             partitions_def=daily_partitions,
             io_manager_key="ADLS2PickleIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
+            output_mode="all",
         )
         def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             result = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
@@ -499,15 +472,11 @@ def dynamic_graph_asset(
 
         File from each graph dimension:
 
-        class MyAssetConfig(dg.Config):
-            disease: List[str]
-            state: List[str]
-            container: str
-
         @dynamic_graph_asset(
             partitions_def=daily_partitions,
             io_manager_key="ADLS2FilesystemIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
+            output_mode="all",
         )
         def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset):
             output_path = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
@@ -531,12 +500,6 @@ def dynamic_graph_asset(
                     └── FLU_NY.txt
 
     """
-
-    if callable(ins):
-        _fn = ins
-        ins = None
-    else:
-        _fn = None
 
     def decorator(fn):
         asset_name = fn.__name__
@@ -904,6 +867,6 @@ def dynamic_graph_asset(
 
             return _asset
 
-    if _fn is not None:
-        return decorator(_fn)
+    if fn is not None:
+        return decorator(fn)
     return decorator

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     cast,
     Generic,
-    List,
     Mapping,
     Optional,
     TypedDict,
@@ -101,7 +100,49 @@ class GraphDimension(dg.Config, Generic[T]):
         return self._current_value
 
 
-def _get_dimension_resources(
+def _get_return_info(asset_name, hints, fn) -> tuple[bool, bool]:
+    """ 
+    Returns a tuple to indicate whether the fn returns a value and if it
+    is annotated with a Sequence return type
+    """
+    return_type = hints.get("return")
+    log.debug(f"return_type: '{return_type}'")
+    origin = get_origin(return_type) or return_type
+
+    is_annotated_sequence = (
+        isinstance(origin, type)
+        and issubclass(origin, Sequence)
+        and not issubclass(origin, (str, bytes))
+    )
+    log.debug(f"is_annotated_sequence: '{is_annotated_sequence}'")
+
+    does_return_value = inspect.isgeneratorfunction(
+        fn
+    ) or _has_return_value(fn)
+    log.debug(f"does_return_value: '{does_return_value}'")
+
+    if does_return_value and return_type is None:
+        raise ValueError(
+            f"@dynamic_graph_asset '{asset_name}': decorated function must "
+            "have a return type annotation when returning a value e.g. -> str. Use list[some_type] "
+            "to return the value from each graph_dimension."
+        )
+    return does_return_value, is_annotated_sequence
+
+
+def _get_resource_params(hints) -> dict[str, type]:
+    resource_params: dict[str, type] = {
+        name: hint
+        for name, hint in hints.items()
+        if name != "return"
+        and inspect.isclass(hint)
+        and issubclass(hint, dg.ConfigurableResource)
+    }
+    log.debug(f"resource_params: '{resource_params}'")
+    return resource_params
+
+
+def _get_dimension_resource_info(
     asset_name: str, resource_params: dict[str, type]
 ) -> DimensionResourceInfo:
     dimension_info: DimensionResourceInfo | None = None
@@ -138,6 +179,18 @@ def _get_dimension_resources(
 
     log.debug(f"dimension_resource_info: {dimension_info}")
     return dimension_info
+
+
+def _get_config_cls(hints):
+    config_cls = next(
+        (
+            hint
+            for hint in hints.values()
+            if inspect.isclass(hint) and issubclass(hint, dg.Config) and not issubclass(hint, dg.ConfigurableResource)
+        ),
+        None,
+    )
+    return config_cls
 
 
 def _get_asset_key(asset_name: str, graph_asset_kwargs: GraphAssetKwargs) -> dg.AssetKey:
@@ -277,45 +330,6 @@ def _in_to_asset_in(name: str, op_in: dg.In) -> dg.AssetIn:
     )
 
 
-class DynamicGraphAssetExecutionContext(dg.OpExecutionContext):
-    """
-    OpExecutionContext subclass that exposes the current graph dimension as a dictionary.
-
-        @dynamic_graph_asset(graph_dimensions=["state", "disease"], ...)
-        def my_asset(context: DynamicGraphAssetExecutionContext, config: MyConfig):
-            context.graph_dimension["state"]    # "AK"
-            context.graph_dimension["disease"]  # "COVID-19"
-
-    """
-
-    _mapping_key: dict | None = None
-    _mapping_key_names: list[str] = []
-
-    @property
-    def graph_dimension(self) -> dict[str, str]:
-        if self._mapping_key is None:
-            values = _decode_mapping_key(self.get_mapping_key())
-            self._mapping_key = dict(zip(self._mapping_key_names, values))
-        return self._mapping_key
-
-    @staticmethod
-    def inject(
-        context: dg.OpExecutionContext,
-        mapping_key_names: list[str],
-    ) -> "DynamicGraphAssetExecutionContext":
-        """
-        Patch an existing OpExecutionContext instance into a DynamicGraphAssetExecutionContext
-        by reassigning its __class__ and injecting the mapping key names.
-        This works because DynamicGraphAssetExecutionContext adds no new __init__ parameters.
-        """
-        context.__class__ = DynamicGraphAssetExecutionContext
-        # casting is not enough: AttributeError: 'OpExecutionContext' object has no attribute 'register_output'
-        # context = cast(DynamicGraphAssetExecutionContext, context)
-        context._mapping_key_names = mapping_key_names
-        context._mapping_key = None
-        return context  # type: ignore[return-value]
-
-
 def unpack_output(output) -> tuple[Any, dict]:
     if isinstance(output, dg.Output):
         user_value = output.value
@@ -326,21 +340,56 @@ def unpack_output(output) -> tuple[Any, dict]:
     return user_value, user_metadata
 
 
+def _infer_ins(
+    sig: inspect.Signature,
+    required_resource_keys: set[str],
+    ins: dict[str, dg.In] | None,
+) -> tuple[dict[str, dg.In], dict[str, dg.AssetIn]]:
+    inferred_ins = {
+        name: dg.In()
+        for name in sig.parameters
+        if name not in ["config", "context", *required_resource_keys]
+    }
+    op_ins = {**inferred_ins, **(ins or {})}
+    asset_ins = {
+        name: _in_to_asset_in(name, op_in)
+        for name, op_in in op_ins.items()
+    }
+    return op_ins, asset_ins
+
+
+def _apply_graph_dimensions(
+    context: dg.OpExecutionContext,
+    dimension_resource_info: DimensionResourceInfo,
+    graph_dimensions: dict[str, str],
+) -> Any:
+    dimension_resource = getattr(
+        context.resources,
+        dimension_resource_info.param_name,
+    )
+    for field_name, value in graph_dimensions.items():
+        graph_dim_obj = cast(
+            GraphDimension,
+            getattr(dimension_resource, field_name),
+        )
+        graph_dim_obj.set_current_value(value)
+    return dimension_resource
+
+
 # -- Decorator --
 def dynamic_graph_asset(
-    graph_dimensions: List[str],
     ins: dict[str, dg.In] = None,
     io_manager_key: Optional[str] = None,
     retry_policy: Optional[dg.RetryPolicy] = None,
     **graph_asset_kwargs: Unpack[GraphAssetKwargs],
 ):
     """
-    Decorator that wires a function into a dynamic graph asset to run steps in parallel based on provided Config.
+    Decorator that wires a function into a dynamic graph asset to run steps in parallel based on a provided ConfigurableResource.
     See https://docs.dagster.io/guides/build/ops/dynamic-graphs#using-dynamic-outputs
     and https://docs.dagster.io/guides/build/assets/graph-backed-assets
 
     The decorated function becomes the compute op, called once per combination
-    of graph_dimensions field values. Config fields listed in `graph_dimensions` are unpacked to
+    of graph_dimensions field values. ConfigurableResource fields types as `GraphDimension`s  are unpacked to
     single scalar values inside the function body.
 
     graph_dimensions values are encoded into the internal op mapping key using _XX_ hex escaping
@@ -354,10 +403,6 @@ def dynamic_graph_asset(
     Downstream assets using the ADLS2FilesystemIOManager will download the structured directory automatically.
 
     Args:
-        graph_dimensions: List of config field names to fan out over. Must be iterable
-                fields on the Config class (e.g. List[str]). The cartesian
-                product of all fields becomes the set of dynamic mapping keys.
-
         name (Optional[str]): The name of the asset.  If not provided, defaults to the name of the
             decorated function. The asset's name must be a valid name in Dagster (ie only contains
             letters, numbers, and underscores) and may not contain Python reserved keywords.
@@ -414,20 +459,28 @@ def dynamic_graph_asset(
 
 
     Example:
-        Single value for all graph dimensions:
+        Define ConfigurableResource with GraphDimensions:
 
-        class MyAssetConfig(dg.Config):
-            disease: List[str]
-            state: List[str]
+        class MyConfig(dg.ConfigurableResource):
+            disease: Dimension[str] = Dimension(["covid", "flu", "rsv"])
+            state: Dimension[str] = Dimension(["CA", "TX", "NY"])
             container: str
 
+        defs = dg.Definitions(
+            ...
+            resources = {
+                "my_config": MyConfig()
+            }
+        )
+
+        Single value for all graph dimensions:
+
         @dynamic_graph_asset(
-            graph_dimensions=["disease", "state"],
             partitions_def=daily_partitions,
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> str:
-            my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> str:
+            my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=f"staging/{context.partition_key}",
                 metadata={"container": config.base_output_prefix},
@@ -436,19 +489,14 @@ def dynamic_graph_asset(
 
         Aggregated value from each graph dimension:
 
-        class MyAssetConfig(dg.Config):
-            disease: List[str]
-            state: List[str]
-            container: str
 
         @dynamic_graph_asset(
-            graph_dimensions=["disease", "state"],
             partitions_def=daily_partitions,
             io_manager_key="ADLS2PickleIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[str]:
-            result = my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> list[str]:
+            result = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=result,
                 metadata={"container": config.base_output_prefix},
@@ -463,13 +511,12 @@ def dynamic_graph_asset(
             container: str
 
         @dynamic_graph_asset(
-            graph_dimensions=["disease", "state"],
             partitions_def=daily_partitions,
             io_manager_key="ADLS2FilesystemIOManager",
             ins={"upstream": dg.AssetIn("some_upstream_asset")},
         )
-        def my_dynamic_asset(context: dg.OpExecutionContext, config: MyAssetConfig, upstream_asset) -> list[Path]:
-            output_path = my_code_pipeline(context.graph_dimension["disease"], context.graph_dimension["state"], upstream_asset)
+        def my_dynamic_asset(context: dg.OpExecutionContext, my_config: MyConfig, upstream_asset) -> list[Path]:
+            output_path = my_code_pipeline(my_config.disease.current_value, my_config.state.current_value, upstream_asset)
             return dg.Output(
                 value=output_path,
                 metadata={"container": config.base_output_prefix},
@@ -494,42 +541,13 @@ def dynamic_graph_asset(
     def decorator(fn):
         asset_name = fn.__name__
 
-        hints = get_type_hints(fn)
-        return_type = hints.get("return")
-        log.debug(f"return_type: '{return_type}'")
-        origin = get_origin(return_type) or return_type
-
-        is_annotated_sequence = (
-            isinstance(origin, type)
-            and issubclass(origin, Sequence)
-            and not issubclass(origin, (str, bytes))
-        )
-        log.debug(f"is_annotated_sequence: '{is_annotated_sequence}'")
-
+        hints = get_type_hints(fn, globalns=vars(sys.modules[fn.__module__]))
         sig = inspect.signature(fn)
 
-        does_return_value = inspect.isgeneratorfunction(
-            fn
-        ) or _has_return_value(fn)
-        log.debug(f"does_return_value: '{does_return_value}'")
-
-        if does_return_value and return_type is None:
-            raise ValueError(
-                f"@dynamic_graph_asset '{asset_name}': decorated function must "
-                "have a return type annotation when returning a value e.g. -> str. Use list[some_type] "
-                "to return the value from each graph_dimension."
-            )
+        does_return_value, is_annotated_sequence = _get_return_info(asset_name, hints, fn)
 
         # -- Locate the Config parameter --
-        hints = get_type_hints(fn, globalns=vars(sys.modules[fn.__module__]))
-        config_cls = next(
-            (
-                hint
-                for hint in hints.values()
-                if inspect.isclass(hint) and issubclass(hint, dg.Config) and not issubclass(hint, dg.ConfigurableResource)
-            ),
-            None,
-        )
+        config_cls = _get_config_cls(hints)
 
         # capture kwargs from decorated function to be later used in compute op
         decorated_fn_kwargs = {
@@ -545,20 +563,8 @@ def dynamic_graph_asset(
 
         final_asset_key = _get_asset_key(asset_name, graph_asset_kwargs)
 
-        # check for partitions
-        has_partitions = graph_asset_kwargs.get("partitions_def") is not None
-        log.debug(f"has_partitions: '{has_partitions}'")
-
         # -- Locate Resource parameters --
-        # Maps parameter name -> resource class for all ConfigurableResource-annotated params
-        resource_params: dict[str, type] = {
-            name: hint
-            for name, hint in hints.items()
-            if name != "return"
-            and inspect.isclass(hint)
-            and issubclass(hint, dg.ConfigurableResource)
-        }
-        log.debug(f"resource_params: '{resource_params}'")
+        resource_params = _get_resource_params(hints)
 
         # Build the required_resource_keys set so @graph_asset and inner @op
         # declarations both declare the resources they need
@@ -566,25 +572,9 @@ def dynamic_graph_asset(
         log.debug(f"required_resource_keys: '{required_resource_keys}'")
 
         # -- Locate resources containing GraphDimension fields --
-        dimension_resource_info = _get_dimension_resources(asset_name, resource_params)
+        dimension_resource_info = _get_dimension_resource_info(asset_name, resource_params)
 
-        # Infer upstream op ins from all parameters that aren't context or config
-        inferred_ins = {
-            name: dg.In()
-            for name in sig.parameters
-            if name not in ["config", "context", *required_resource_keys]
-        }
-
-        # User overrides at op level
-        op_ins = {**inferred_ins, **(ins or {})}
-
-        # Asset-level ins for @graph_asset
-        asset_ins: dict[str, dg.AssetIn] = {
-            name: _in_to_asset_in(name, op_in)
-            for name, op_in in op_ins.items()
-        }
-
-        log.debug(f"inferred_ins: '{inferred_ins}'")
+        op_ins, asset_ins = _infer_ins(sig, required_resource_keys, ins)
         log.debug(f"op_ins: '{op_ins}'")
         log.debug(f"asset_ins: '{asset_ins}'")
 
@@ -706,46 +696,16 @@ def dynamic_graph_asset(
             }
             log.debug(f"resource_kwargs: {resource_kwargs}")
 
-            # Current mapping key (Dagster provides this via dynamic mapping context)
+            # decode graph_dimensions from mapping_key
             mapping_key = cast(str, context.get_mapping_key())
-            log.debug(f"mapping_key: '{mapping_key}'")
-
-            # Decode mapping key back into tuple of values
-            # (assumes your _encode_mapping_key is reversible)
-            decoded_mapping_key = _decode_mapping_key(mapping_key)
-
-            graph_dimensions = {
-                    field: value
-                    for field, value in zip(
-                        dimension_resource_info.dimension_fields,
-                        decoded_mapping_key
-                        )
-                    }
-
+            decoded = _decode_mapping_key(mapping_key)
+            graph_dimensions = dict(zip(dimension_resource_info.dimension_fields, decoded))
             log.debug(f"graph_dimensions: '{graph_dimensions}'")
 
-            # Apply to resource instance for THIS op only
-            dimension_resource = getattr(
-                context.resources,
-                dimension_resource_info.param_name,
-            )
-
-            for field_name, value in graph_dimensions.items():
-                graph_dim_obj = cast(
-                        GraphDimension,
-                        getattr(dimension_resource, field_name)
-                        )
-
-                graph_dim_obj.set_current_value(value)
-
-            # ----------------------------
-            # Optional: "first dimension" check (now simpler + correct)
-            # ----------------------------
+            dimension_resource = _apply_graph_dimensions(context, dimension_resource_info, graph_dimensions)
 
             is_first_dimension = all(
-                graph_dimensions[field] == getattr(
-                    dimension_resource, field
-                ).values[0]
+                graph_dimensions[field] == getattr(dimension_resource, field).values[0]
                 for field in dimension_resource_info.dimension_fields
             )
 

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -90,6 +90,20 @@ class GraphDimension(dg.Config, Generic[T]):
         return self._current_value
 
 
+class GraphDimensionExclusion(dg.Config, Generic[T]):
+    values: list[T] = []
+
+    def __init__(self, values: list[str]):
+        super().__init__(values=values)
+
+
+@dataclass
+class ExclusionResourceInfo:
+    param_name: str
+    resource_cls: type
+    exclusion_fields: list[str]
+
+
 def _get_resource_params(hints) -> dict[str, type]:
     resource_params: dict[str, type] = {
         name: hint
@@ -139,6 +153,48 @@ def _get_dimension_resource_info(
 
     log.debug(f"dimension_resource_info: {dimension_info}")
     return dimension_info
+
+
+def _get_exclusion_resource_info(
+    asset_name: str,
+    resource_params: dict[str, type],
+    dimension_fields: list[str],
+) -> list[ExclusionResourceInfo]:
+    exclusion_infos: list[ExclusionResourceInfo] = []
+
+    for param_name, resource_cls in resource_params.items():
+        resource_hints = get_type_hints(resource_cls)
+
+        exclusion_fields = [
+            field_name
+            for field_name, annotation in resource_hints.items()
+            if _is_exclusion_annotation(annotation)
+        ]
+
+        if not exclusion_fields:
+            continue
+
+        # Validate that all exclusion field names match dimension field names
+        for field in exclusion_fields:
+            if field not in dimension_fields:
+                raise ValueError(
+                    f"@dynamic_graph_asset '{asset_name}': "
+                    f"GraphDimensionExclusion field '{field}' in resource "
+                    f"'{param_name}' does not match any GraphDimension field. "
+                    f"Available dimension fields: {dimension_fields}"
+                )
+
+        exclusion_infos.append(
+            ExclusionResourceInfo(
+                param_name=param_name,
+                resource_cls=resource_cls,
+                exclusion_fields=exclusion_fields,
+            )
+        )
+
+    if exclusion_infos:
+        log.debug(f"exclusion_resource_infos: {exclusion_infos}")
+    return exclusion_infos
 
 
 def _get_config_cls(hints):
@@ -191,6 +247,22 @@ def _is_dimension_annotation(annotation) -> bool:
     )
 
     return metadata is not None and metadata.get("origin") is GraphDimension
+
+
+def _is_exclusion_annotation(annotation) -> bool:
+    if get_origin(annotation) is GraphDimensionExclusion:
+        return True
+
+    metadata = getattr(
+        annotation,
+        "__pydantic_generic_metadata__",
+        None,
+    )
+
+    return (
+        metadata is not None
+        and metadata.get("origin") is GraphDimensionExclusion
+    )
 
 
 def _has_return_value(fn) -> bool:
@@ -544,6 +616,13 @@ def dynamic_graph_asset(
             asset_name, resource_params
         )
 
+        # -- Locate resources containing GraphDimensionExclusion fields --
+        exclusion_resources_info = _get_exclusion_resource_info(
+            asset_name,
+            resource_params,
+            dimension_resource_info.dimension_fields,
+        )
+
         op_ins, asset_ins = _infer_ins(sig, resource_params_keys, ins)
         log.debug(f"op_ins: '{op_ins}'")
         log.debug(f"asset_ins: '{asset_ins}'")
@@ -608,7 +687,26 @@ def dynamic_graph_asset(
                     dimension_field,
                 )
 
-                axes.append(graph_dimension.values)
+                values = graph_dimension.values
+
+                # filter out excluded dimension values across all exclusion resources
+                if exclusion_resources_info:
+                    excluded_values: set = set()
+                    for excl_info in exclusion_resources_info:
+                        excl_resource = getattr(
+                            context.resources, excl_info.param_name
+                        )
+                        exclusion_obj = getattr(
+                            excl_resource, dimension_field, None
+                        )
+                        if exclusion_obj is not None and exclusion_obj.values:
+                            excluded_values.update(set(exclusion_obj.values))
+                    if excluded_values:
+                        values = [
+                            v for v in values if v not in excluded_values
+                        ]
+
+                axes.append(values)
 
             for combo in itertools.product(*axes):
                 mapping_key = _encode_mapping_key(combo)

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -11,10 +11,12 @@ from types import GeneratorType
 from typing import (
     AbstractSet,
     Any,
+    Generic,
     List,
     Mapping,
     Optional,
     TypedDict,
+    TypeVar,
     Union,
     get_origin,
     get_type_hints,
@@ -33,10 +35,141 @@ from typing_extensions import Unpack
 from .azure_adls2.filesystem_metadata import ADLS2FilesystemIOManagerMetadata
 from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
 from .execution.utils import ExecutionConfig, SelectorConfig
+from pydantic import PrivateAttr
 
 log = logging.getLogger(__name__)
 
 INTERNAL_CONFIG_IO_MANAGER = ADLS2PickleIOManager().get_resource_definition()
+
+# NOTE: Goals for graph_dimension
+# - single-definition of graph_dimension
+# - type-safe access e.g. resource.graph_dimension_property instead of context.graph_dimensions["graph_dimension_property"] so users get an error when accessing an invalid graph_dimension
+# - a 'strict' graph_dimension option using automatically-generated enums e.g. user provides state: list[str] = ["CA", "TX", "NY"] and Launchpad prevents state.WY
+
+# NOTE: Requirements:
+# - GraphDimension type for IDE-level autocomplete
+# - class decorator or subclass for auto-enum behavior UPDATE: not feasible with decorator. Subclass might be overkill
+
+# NOTE: Tradeoffs:
+
+
+class GraphAssetKwargs(TypedDict, total=False):
+    name: Optional[str] = (None,)
+    description: Optional[str] = (None,)
+    # ins: Optional[Mapping[str, dg.AssetIn]] = None,
+    config: Optional[Union[dg.ConfigMapping, Mapping[str, Any]]] = (None,)
+    key_prefix: Optional[CoercibleToAssetKeyPrefix] = (None,)
+    group_name: Optional[str] = (None,)
+    partitions_def: Optional[dg.PartitionsDefinition] = (None,)
+    hooks: Optional[AbstractSet[dg.HookDefinition]] = (None,)
+    metadata: Optional[RawMetadataMapping] = (None,)
+    tags: Optional[Mapping[str, str]] = (None,)
+    owners: Optional[TypeSequence[str]] = (None,)
+    automation_condition: Optional[dg.AutomationCondition] = (None,)
+    backfill_policy: Optional[dg.BackfillPolicy] = (None,)
+    resource_defs: Optional[Mapping[str, dg.ResourceDefinition]] = (None,)
+    check_specs: Optional[TypeSequence[dg.AssetCheckSpec]] = (None,)
+    code_version: Optional[str] = (None,)
+    key: Optional[CoercibleToAssetKey] = (None,)
+    kinds: Optional[AbstractSet[str]] = (None,)
+
+
+
+
+T = TypeVar("T", default=str)
+
+
+class GraphDimension(dg.Config, Generic[T]):
+    values: list[T]
+    _current_value: Optional[T] = PrivateAttr(default=None)
+
+    def __init__(self, values: list[str], current_value: Optional[str] = None):
+        super().__init__(values=values, _current_value=current_value)
+
+    def set_current_value(self, value: T) -> None:
+        self._current_value = value
+
+    @property
+    def current_value(self) -> Optional[T]:
+        return self._current_value
+
+def _get_dimension_resources(asset_name, resource_params: dict) -> dict[str, type]:
+    # -- Locate resources containing GraphDimension fields --
+    dimension_resources: dict[str, type] = {}
+
+    for param_name, resource_cls in resource_params.items():
+        resource_hints = get_type_hints(resource_cls)
+
+        dimension_fields = []
+
+        for field_name, annotation in resource_hints.items():
+            origin = get_origin(annotation)
+
+            dimension_fields = [
+                field_name
+                for field_name, annotation in resource_hints.items()
+                if _is_dimension_annotation(annotation)
+            ]
+
+        if dimension_fields:
+            dimension_resources[param_name] = {
+                "resource_cls": resource_cls,
+                "dimension_fields": dimension_fields,
+            }
+
+    log.debug(f"dimension_resources: {dimension_resources}")
+
+    if len(dimension_resources) == 0:
+        # raise ValueError(
+        log.debug(
+            f"@dynamic_graph_asset '{asset_name}': "
+            "No ConfigurableResource parameter contains GraphDimension fields."
+        )
+
+    if len(dimension_resources) > 1:
+        # raise ValueError(
+        log.debug(
+            f"@dynamic_graph_asset '{asset_name}': "
+            "Multiple ConfigurableResources contain GraphDimension fields. "
+            f"Found: {list(dimension_resources.keys())}"
+        )
+    return dimension_resources
+
+
+def _get_asset_key(asset_name: str, graph_asset_kwargs: GraphAssetKwargs) -> dg.AssetKey:
+    base_key = graph_asset_kwargs.get("key") or asset_name
+    final_asset_key = base_key
+
+    # Apply key prefix if provided
+    key_prefix = graph_asset_kwargs.get("key_prefix")
+    if key_prefix:
+        # Support list or single string
+        if isinstance(key_prefix, str):
+            final_asset_key = dg.AssetKey([key_prefix, base_key])
+        elif isinstance(key_prefix, list):
+            final_asset_key = dg.AssetKey(key_prefix + [base_key])
+        else:
+            raise ValueError("key_prefix must be str or list of str")
+    else:
+        final_asset_key = dg.AssetKey(base_key)
+    log.debug(f"final_asset_key: '{final_asset_key}'")
+    return final_asset_key
+
+
+def _is_dimension_annotation(annotation) -> bool:
+    if get_origin(annotation) is GraphDimension:
+        return True
+
+    metadata = getattr(
+        annotation,
+        "__pydantic_generic_metadata__",
+        None,
+    )
+
+    return (
+        metadata is not None
+        and metadata.get("origin") is GraphDimension
+    )
 
 
 def _has_return_value(fn) -> bool:
@@ -184,27 +317,6 @@ def unpack_output(output) -> tuple[Any, dict]:
         user_value = output
         user_metadata = {}
     return user_value, user_metadata
-
-
-class GraphAssetKwargs(TypedDict, total=False):
-    name: Optional[str] = (None,)
-    description: Optional[str] = (None,)
-    # ins: Optional[Mapping[str, dg.AssetIn]] = None,
-    config: Optional[Union[dg.ConfigMapping, Mapping[str, Any]]] = (None,)
-    key_prefix: Optional[CoercibleToAssetKeyPrefix] = (None,)
-    group_name: Optional[str] = (None,)
-    partitions_def: Optional[dg.PartitionsDefinition] = (None,)
-    hooks: Optional[AbstractSet[dg.HookDefinition]] = (None,)
-    metadata: Optional[RawMetadataMapping] = (None,)
-    tags: Optional[Mapping[str, str]] = (None,)
-    owners: Optional[TypeSequence[str]] = (None,)
-    automation_condition: Optional[dg.AutomationCondition] = (None,)
-    backfill_policy: Optional[dg.BackfillPolicy] = (None,)
-    resource_defs: Optional[Mapping[str, dg.ResourceDefinition]] = (None,)
-    check_specs: Optional[TypeSequence[dg.AssetCheckSpec]] = (None,)
-    code_version: Optional[str] = (None,)
-    key: Optional[CoercibleToAssetKey] = (None,)
-    kinds: Optional[AbstractSet[str]] = (None,)
 
 
 # -- Decorator --
@@ -407,32 +519,10 @@ def dynamic_graph_asset(
             (
                 hint
                 for hint in hints.values()
-                if inspect.isclass(hint) and issubclass(hint, dg.Config)
+                if inspect.isclass(hint) and issubclass(hint, dg.Config) and not issubclass(hint, dg.ConfigurableResource)
             ),
             None,
         )
-        if config_cls is None:
-            raise ValueError(
-                f"@dynamic_graph_asset '{asset_name}': decorated function must have a "
-                f"parameter annotated with a dg.Config subclass"
-            )
-
-        # -- Validate graph_dimensions fields --
-        for field in graph_dimensions:
-            if field not in config_cls.model_fields:
-                raise ValueError(
-                    f"@dynamic_graph_asset '{asset_name}': graph_dimensions field '{field}' "
-                    f"does not exist on {config_cls.__name__}. "
-                    f"Available fields: {list(config_cls.model_fields.keys())}"
-                )
-            field_annotation = config_cls.model_fields[field].annotation
-            origin = get_origin(field_annotation)
-            if origin is None or origin not in (list, tuple, set, frozenset):
-                raise ValueError(
-                    f"@dynamic_graph_asset '{asset_name}': graph_dimensions field '{field}' "
-                    f"on {config_cls.__name__} must be an iterable type (e.g. list[str]), "
-                    f"got '{field_annotation}'"
-                )
 
         # capture kwargs from decorated function to be later used in compute op
         decorated_fn_kwargs = {
@@ -446,23 +536,7 @@ def dynamic_graph_asset(
         }
         log.debug(f"decorated_fn_kwargs: {decorated_fn_kwargs}")
 
-        # Determine the base key: explicit key or function name
-        base_key = graph_asset_kwargs.get("key") or fn.__name__
-        final_asset_key = base_key
-
-        # Apply key prefix if provided
-        key_prefix = graph_asset_kwargs.get("key_prefix")
-        if key_prefix:
-            # Support list or single string
-            if isinstance(key_prefix, str):
-                final_asset_key = dg.AssetKey([key_prefix, base_key])
-            elif isinstance(key_prefix, list):
-                final_asset_key = dg.AssetKey(key_prefix + [base_key])
-            else:
-                raise ValueError("key_prefix must be str or list of str")
-        else:
-            final_asset_key = dg.AssetKey(base_key)
-        log.debug(f"final_asset_key: '{final_asset_key}'")
+        final_asset_key = _get_asset_key(asset_name, graph_asset_kwargs)
 
         # check for partitions
         has_partitions = graph_asset_kwargs.get("partitions_def") is not None
@@ -483,6 +557,9 @@ def dynamic_graph_asset(
         # declarations both declare the resources they need
         required_resource_keys: set[str] = set(resource_params.keys())
         log.debug(f"required_resource_keys: '{required_resource_keys}'")
+
+        # -- Locate resources containing GraphDimension fields --
+        dimension_resources = _get_dimension_resources(asset_name, resource_params)
 
         # Infer upstream op ins from all parameters that aren't context or config
         inferred_ins = {
@@ -525,7 +602,7 @@ def dynamic_graph_asset(
                     io_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
                 ),
             },
-            required_resource_keys=[INTERNAL_CONFIG_IO_MANAGER_KEY],
+            required_resource_keys=[INTERNAL_CONFIG_IO_MANAGER_KEY] + list(dimension_resources.keys()),
             tags=in_process_config.to_run_tags(),
         )
         def gen_config(context, **kwargs):
@@ -539,15 +616,43 @@ def dynamic_graph_asset(
             )
 
             # Generate dynamic fanout keys
-            axes = [getattr(config, field) for field in graph_dimensions]
+            # axes = [getattr(config, field) for field in graph_dimensions]
+            #
+            # for combo in itertools.product(*axes):
+            #     mapping_key = _encode_mapping_key(combo)
+            #     yield dg.DynamicOutput(
+            #         value=None,
+            #         mapping_key=mapping_key,
+            #         output_name="dga_internal_fanout",
+            #     )
+            # There should be exactly one dimension resource
+            dimension_resource_name, dimension_resource_info = next(
+                iter(dimension_resources.items())
+            )
+
+            dimension_resource = getattr(
+                context.resources,
+                dimension_resource_name,
+            )
+
+            axes = []
+
+            for dimension_field in dimension_resource_info["dimension_fields"]:
+                graph_dimension = getattr(
+                    dimension_resource,
+                    dimension_field,
+                )
+
+                axes.append(graph_dimension.values)
 
             for combo in itertools.product(*axes):
                 mapping_key = _encode_mapping_key(combo)
+
                 yield dg.DynamicOutput(
-                    value=None,
-                    mapping_key=mapping_key,
-                    output_name="dga_internal_fanout",
-                )
+                        value=None,
+                        mapping_key=mapping_key,
+                        output_name="dga_internal_fanout",
+                        )
 
         # -- compute op to run decorated function body --
         @dg.op(
@@ -581,34 +686,98 @@ def dynamic_graph_asset(
             retry_policy=retry_policy,
             config_schema=config_cls.to_config_schema(),
         )
-        def compute(context, dga_internal_shared_config, **kwargs):
+        def compute(
+                context: dg.OpExecutionContext,
+                dga_internal_shared_config,
+                **kwargs,
+                ):
             upstream_kwargs = {
                 k: v for k, v in kwargs.items() if k in decorated_fn_kwargs
             }
+            log.debug(f"upstream_kwargs: {upstream_kwargs}")
             # Pull each declared resource off context and pass it through to fn
             resource_kwargs = {
                 name: getattr(context.resources, name)
                 for name in resource_params
             }
-            dynamic_context = DynamicGraphAssetExecutionContext.inject(
-                context,
-                graph_dimensions,
-            )
+            log.debug(f"resource_kwargs: {resource_kwargs}")
+
             config = config_cls(**dga_internal_shared_config)
             log.debug(f"config: '{config}'")
-            graph_dimension = dynamic_context.graph_dimension
+
+            # is_first_dimension = all(
+            #     graph_dimension.get(key) == values[0]
+            #     # for key, values in config.dict().items()
+            #     for key, values in config.model_dump().items()
+            #     if key in graph_dimension
+            # )
+            # log.debug(f"is_first_dimension: '{is_first_dimension}'")
+
+            # ----------------------------
+            # Build graph dimension state
+            # from dimension_resources
+            # ----------------------------
+
+            # Expect only one fanout resource (same assumption as config op)
+            dimension_resource_name, dimension_resource_info = next(
+                iter(dimension_resources.items())
+            )
+
+            dimension_resource = getattr(
+                context.resources,
+                dimension_resource_name,
+            )
+
+            # Current mapping key (Dagster provides this via dynamic mapping context)
+            # mapping_key = context.dagster_run.tags.get("dagster/map_key", None)
+            mapping_key = context.get_mapping_key()
+            log.debug(f"mapping_key: '{mapping_key}'")
+
+            # Decode mapping key back into tuple of values
+            # (assumes your _encode_mapping_key is reversible)
+            current_combo = _decode_mapping_key(mapping_key)
+
+            dimension_fields = dimension_resource_info["dimension_fields"]
+
+            graph_dimension = {
+                field: value
+                for field, value in zip(dimension_fields, current_combo)
+            }
+
             log.debug(f"graph_dimension: '{graph_dimension}'")
 
-            is_first_dimension = all(
-                graph_dimension.get(key) == values[0]
-                for key, values in config.dict().items()
-                if key in graph_dimension
+            # Apply to resource instance for THIS op only
+            for field_name, value in graph_dimension.items():
+                graph_dim_obj = getattr(dimension_resource, field_name)
+
+                graph_dim_obj: GraphDimension = graph_dim_obj
+                graph_dim_obj.set_current_value(value)
+
+            # ----------------------------
+            # Replace DynamicGraphAssetExecutionContext.inject
+            # ----------------------------
+
+            dynamic_context = DynamicGraphAssetExecutionContext.inject(
+                context,
+                graph_dimension,
             )
+
+            # ----------------------------
+            # Optional: "first dimension" check (now simpler + correct)
+            # ----------------------------
+
+            is_first_dimension = all(
+                graph_dimension[field] == getattr(
+                    dimension_resource, field
+                ).values[0]
+                for field in dimension_fields
+            )
+
             log.debug(f"is_first_dimension: '{is_first_dimension}'")
 
             result = fn(
-                dynamic_context,
-                config,
+                context,
+                # config,
                 **upstream_kwargs,
                 **resource_kwargs,
             )
@@ -624,11 +793,11 @@ def dynamic_graph_asset(
                     **dict(metadata),
                     **ADLS2FilesystemIOManagerMetadata(
                         asset_key_path=final_asset_key.path,
-                        asset_partition_keys=dynamic_context.partition_keys
-                        if dynamic_context.has_partition_key
+                        asset_partition_keys=context.partition_keys
+                        if context.has_partition_key
                         else [],
                         synthetic_partition_keys=list(
-                            dynamic_context.graph_dimension.values()
+                            context.graph_dimension.values()
                         ),
                     ).to_dict(),
                 }

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -303,13 +303,13 @@ def unpack_output(output) -> tuple[Any, dict]:
 
 def _infer_ins(
     sig: inspect.Signature,
-    required_resource_keys: set[str],
+    resource_params_keys: set[str],
     ins: dict[str, dg.In] | None,
 ) -> tuple[dict[str, dg.In], dict[str, dg.AssetIn]]:
     inferred_ins = {
         name: dg.In()
         for name in sig.parameters
-        if name not in ["config", "context", *required_resource_keys]
+        if name not in ["config", "context", *resource_params_keys]
     }
     op_ins = {**inferred_ins, **(ins or {})}
     asset_ins = {
@@ -534,17 +534,17 @@ def dynamic_graph_asset(
         # -- Locate Resource parameters --
         resource_params = _get_resource_params(hints)
 
-        # Build the required_resource_keys set so @graph_asset and inner @op
+        # Build the resource_params_keys set so @graph_asset and inner @op
         # declarations both declare the resources they need
-        required_resource_keys: set[str] = set(resource_params.keys())
-        log.debug(f"required_resource_keys: '{required_resource_keys}'")
+        resource_params_keys: set[str] = set(resource_params.keys())
+        log.debug(f"resource_params_keys: '{resource_params_keys}'")
 
         # -- Locate resources containing GraphDimension fields --
         dimension_resource_info = _get_dimension_resource_info(
             asset_name, resource_params
         )
 
-        op_ins, asset_ins = _infer_ins(sig, required_resource_keys, ins)
+        op_ins, asset_ins = _infer_ins(sig, resource_params_keys, ins)
         log.debug(f"op_ins: '{op_ins}'")
         log.debug(f"asset_ins: '{asset_ins}'")
 
@@ -552,6 +552,12 @@ def dynamic_graph_asset(
         # between isolated mapped compute steps.
         INTERNAL_CONFIG_IO_MANAGER_KEY = (
             "internal_dynamic_graph_asset_io_manager"
+        )
+
+        required_resource_keys = (
+            list(resource_params_keys)
+            + list(graph_asset_kwargs.get("resource_defs", {}).keys())
+            + [INTERNAL_CONFIG_IO_MANAGER_KEY]
         )
 
         # -- config op to create DynamicOutputs for fanout --
@@ -575,10 +581,7 @@ def dynamic_graph_asset(
                     else {}
                 ),
             },
-            required_resource_keys=[
-                INTERNAL_CONFIG_IO_MANAGER_KEY,
-                dimension_resource_info.param_name,
-            ],
+            required_resource_keys=required_resource_keys,
             tags=in_process_config.to_run_tags(),
         )
         def gen_config(context, **kwargs):
@@ -648,9 +651,7 @@ def dynamic_graph_asset(
                 else {"out": dg.Out(dg.Nothing)}
             ),
             # set resources based on decorated fn signature, explicit decorator param, and internal io manager
-            required_resource_keys=list(required_resource_keys)
-            + list(graph_asset_kwargs.get("resource_defs", {}).keys())
-            + [INTERNAL_CONFIG_IO_MANAGER_KEY],
+            required_resource_keys=required_resource_keys,
             retry_policy=retry_policy,
             config_schema=config_cls.to_config_schema()
             if config_cls

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -208,7 +208,14 @@ def _run_cli(
 
     has_subcommand = any(not arg.startswith("-") for arg in raw_args[1:])
 
+    first_subcommand = next(
+        (arg for arg in raw_args[1:] if not arg.startswith("-")),
+        None,
+    )
+
     def should_retry():
+        if first_subcommand == "check":
+            return False
         return has_subcommand or retry_without_subcommand
 
     def retry_with_defs_file():

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "cfa-dagster"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Closes #120

This PR is a significant refactor of the `@dynamic_graph_asset` to source `graph_dimensions` from a `dg.ConfigurableResource` instead of `dg.Config`. This change allows multiple assets to share the same `graph_dimensions` with a single point of configuration in the Launchpad.

In addition, output behavior has been made more explicit. Rather than using the asset return type (`list[str]` vs `str`), there is now an `output_mode` parameter to determine whether outputs from all graph dimensions or just the first dimension should be returned.

Closes #127 
Quick fix to prevent `cfa-dg check defs` from retrying with `cfa-dg check defs -f dagster_defs.py` on error

Closes #128
Update to load  `ConfigurableResources` in the inital config op for `@dynamic_graph_assets` to run validation before generating potentially many compute ops