### PR TITLE
Upgrade Azure Batch dependency to 15.1.0

### DIFF
--- a/examples/dagster_defs.py
+++ b/examples/dagster_defs.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.13,<3.14"
 # dependencies = [
-#    "cfa-dagster[dev] @ git+https://github.com/cdcgov/cfa-dagster.git@gio-batch-upgrade",
+#    "cfa-dagster[dev] @ git+https://github.com/cdcgov/cfa-dagster.git",
 # ]
 # ///
 
@@ -17,7 +17,6 @@ from dagster_azure.blob import (
     AzureBlobStorageResource,
 )
 
-from time import sleep
 # ruff: noqa: F401
 from cfa_dagster import (
     ADLS2PickleIOManager,
@@ -42,7 +41,6 @@ user = os.getenv("DAGSTER_USER")
 IMAGE_REGISTRY = "cfaprdbatchcr"
 image_tag = "latest" if is_production() else user
 image = f"{IMAGE_REGISTRY}.azurecr.io/cfa-dagster:{image_tag}"
-image = "ghcr.io/giomrella/cfa_dagster:latest"
 
 # ----------------
 # Execution Config - defines where your workflows run
@@ -144,7 +142,6 @@ def basic_blob_asset(azure_blob_storage: AzureBlobStorageResource):
         )
     downloader = container_client.download_blob("test-files/test_config.json")
     print("Downloaded file from blob!")
-    sleep(600)
     return downloader.readall().decode("utf-8")
 
 

--- a/examples/dagster_defs.py
+++ b/examples/dagster_defs.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.13,<3.14"
 # dependencies = [
-#    "cfa-dagster[dev] @ git+https://github.com/cdcgov/cfa-dagster.git",
+#    "cfa-dagster[dev] @ git+https://github.com/cdcgov/cfa-dagster.git@gio-batch-upgrade",
 # ]
 # ///
 
@@ -17,6 +17,7 @@ from dagster_azure.blob import (
     AzureBlobStorageResource,
 )
 
+from time import sleep
 # ruff: noqa: F401
 from cfa_dagster import (
     ADLS2PickleIOManager,
@@ -41,6 +42,7 @@ user = os.getenv("DAGSTER_USER")
 IMAGE_REGISTRY = "cfaprdbatchcr"
 image_tag = "latest" if is_production() else user
 image = f"{IMAGE_REGISTRY}.azurecr.io/cfa-dagster:{image_tag}"
+image = "ghcr.io/giomrella/cfa_dagster:latest"
 
 # ----------------
 # Execution Config - defines where your workflows run
@@ -142,6 +144,7 @@ def basic_blob_asset(azure_blob_storage: AzureBlobStorageResource):
         )
     downloader = container_client.download_blob("test-files/test_config.json")
     print("Downloaded file from blob!")
+    sleep(600)
     return downloader.readall().decode("utf-8")
 
 
@@ -193,11 +196,11 @@ if not is_production():
         cmd = f"docker build -t {image} ."
 
         if should_push:
-            subprocess.run(
-                f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
-                check=True,
-                shell=True,
-            )
+            # subprocess.run(
+            #     f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
+            #     check=True,
+            #     shell=True,
+            # )
             cmd += " --push"
 
         context.log.debug(f"Running {cmd}")

--- a/examples/dagster_defs.py
+++ b/examples/dagster_defs.py
@@ -193,11 +193,11 @@ if not is_production():
         cmd = f"docker build -t {image} ."
 
         if should_push:
-            # subprocess.run(
-            #     f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
-            #     check=True,
-            #     shell=True,
-            # )
+            subprocess.run(
+                f"az login --identity && az acr login -n {IMAGE_REGISTRY}",
+                check=True,
+                shell=True,
+            )
             cmd += " --push"
 
         context.log.debug(f"Running {cmd}")

--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -107,7 +107,8 @@ def cleanup_stale_batch_jobs(
         try:
             context.log.info(f"Terminating idle Batch job: {job_id}")
             batch_client.begin_terminate_job(
-                job_id=job_id, options=BatchJobTerminateOptions()
+                job_id=job_id,
+                options=BatchJobTerminateOptions(termination_reason="cleanup"),
             ).result()
         except HttpResponseError as err:
             context.log.warning(

--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -7,6 +7,7 @@ import dagster as dg
 import requests
 import yaml
 from azure.batch import BatchClient
+from azure.batch.models._models import BatchJobTerminateOptions
 from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.appcontainers import ContainerAppsAPIClient
@@ -105,7 +106,9 @@ def cleanup_stale_batch_jobs(
     for job_id in stale_jobs:
         try:
             context.log.info(f"Terminating idle Batch job: {job_id}")
-            batch_client.begin_terminate_job(job_id=job_id).result()
+            batch_client.begin_terminate_job(
+                job_id=job_id, options=BatchJobTerminateOptions()
+            ).result()
         except HttpResponseError as err:
             context.log.warning(
                 f"Failed to terminate job {job_id}: "

--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -6,18 +6,12 @@ from typing import List
 import dagster as dg
 import requests
 import yaml
-from azure.batch import BatchServiceClient
-from azure.batch.models import (
-    BatchErrorException,
-    JobListOptions,
-    TaskListOptions,
-)
-from azure.core.credentials import TokenCredential
+from azure.batch import BatchClient
+from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.appcontainers import ContainerAppsAPIClient
 from azure.mgmt.msi import ManagedServiceIdentityClient
 from azure.mgmt.subscription import SubscriptionClient
-from msrest.authentication import BasicTokenAuthentication
 
 from cfa_dagster import (
     ADLS2PickleIOManager,
@@ -43,16 +37,14 @@ GRAPHQL_URL = "http://dagster.apps.edav.ext.cdc.gov/graphql"
 
 
 def find_stale_dagster_jobs(
-    batch_client: BatchServiceClient,
+    batch_client: BatchClient,
     idle_threshold: timedelta,
 ) -> List[str]:
     stale_job_ids: List[str] = []
 
-    jobs = batch_client.job.list(
-        job_list_options=JobListOptions(
-            filter="startswith(id,'dagster-') and state eq 'active'",
-            select="id",
-        ),
+    jobs = batch_client.list_jobs(
+        filter="startswith(id,'dagster-') and state eq 'active'",
+        select="id",
     )
 
     cutoff = (datetime.now(timezone.utc) - idle_threshold).isoformat()
@@ -61,17 +53,15 @@ def find_stale_dagster_jobs(
         job_id = job.id
 
         # 1️⃣ Any active tasks? → skip
-        active_tasks = batch_client.task.list(
-            job_id,
-            task_list_options=TaskListOptions(
-                filter=(
-                    "state eq 'active' or "
-                    "state eq 'running' or "
-                    "state eq 'preparing'"
-                ),
-                max_results=1,
-                select="id",
+        active_tasks = batch_client.list_tasks(
+            job_id=job_id,
+            filter=(
+                "state eq 'active' or "
+                "state eq 'running' or "
+                "state eq 'preparing'"
             ),
+            max_results=1,
+            select="id",
         )
 
         if any(True for _ in active_tasks):
@@ -79,13 +69,11 @@ def find_stale_dagster_jobs(
             continue
 
         # 2️⃣ Any recently-created tasks? → skip
-        recent_tasks = batch_client.task.list(
-            job_id,
-            task_list_options=TaskListOptions(
-                filter=f"creationTime ge {cutoff}",
-                max_results=1,
-                select="id",
-            ),
+        recent_tasks = batch_client.list_tasks(
+            job_id=job_id,
+            filter=f"creationTime ge {cutoff}",
+            max_results=1,
+            select="id",
         )
 
         if any(True for _ in recent_tasks):
@@ -117,38 +105,21 @@ def cleanup_stale_batch_jobs(
     for job_id in stale_jobs:
         try:
             context.log.info(f"Terminating idle Batch job: {job_id}")
-            batch_client.job.terminate(job_id)
-        except BatchErrorException as err:
+            batch_client.begin_terminate_job(job_id=job_id).result()
+        except HttpResponseError as err:
             context.log.warning(
                 f"Failed to terminate job {job_id}: "
                 f"{err.error.code if err.error else err}"
             )
 
 
-class AzureIdentityCredentialAdapter(BasicTokenAuthentication):
-    def __init__(self, credential: TokenCredential, scope: str):
-        super().__init__(None)
-        self._credential = credential
-        self._scope = scope
-
-    def signed_session(self, session):
-        token = self._credential.get_token(self._scope)
-        session.headers["Authorization"] = f"Bearer {token.token}"
-        return session
-
-
 @dg.resource
 def batch_client_resource():
     credential = DefaultAzureCredential()
 
-    adapter = AzureIdentityCredentialAdapter(
+    return BatchClient(
+        endpoint="https://cfaprdba.eastus.batch.azure.com",
         credential=credential,
-        scope="https://batch.core.windows.net/.default",
-    )
-
-    return BatchServiceClient(
-        credentials=adapter,
-        batch_url="https://cfaprdba.eastus.batch.azure.com",
     )
 
 

--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -44,7 +44,7 @@ def find_stale_dagster_jobs(
 
     jobs = batch_client.list_jobs(
         filter="startswith(id,'dagster-') and state eq 'active'",
-        select="id",
+        select=["id"],
     )
 
     cutoff = (datetime.now(timezone.utc) - idle_threshold).isoformat()
@@ -61,7 +61,7 @@ def find_stale_dagster_jobs(
                 "state eq 'preparing'"
             ),
             max_results=1,
-            select="id",
+            select=["id"],
         )
 
         if any(True for _ in active_tasks):
@@ -73,7 +73,7 @@ def find_stale_dagster_jobs(
             job_id=job_id,
             filter=f"creationTime ge {cutoff}",
             max_results=1,
-            select="id",
+            select=["id"],
         )
 
         if any(True for _ in recent_tasks):

--- a/infra/pyproject.toml
+++ b/infra/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "azure-identity~=1.25.0",
-    "azure-batch~=14.2.0",
+    "azure-batch~=15.1.0",
     "azure-mgmt-appcontainers~=4.0.0",
     "azure-mgmt-containerinstance~=10.1.0",
     "azure-mgmt-loganalytics~=13.1.0",

--- a/infra/uv.lock
+++ b/infra/uv.lock
@@ -3,21 +3,6 @@ revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
-name = "adal"
-version = "1.2.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyjwt" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/d7/a829bc5e8ff28f82f9e2dc9b363f3b7b9c1194766d5a75105e3885bfa9a8/adal-1.2.7.tar.gz", hash = "sha256:d74f45b81317454d96e982fd1c50e6fb5c99ac2223728aea8764433a39f566f1", size = 35196, upload-time = "2021-04-05T16:33:40.88Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/8d/58008a9a86075827f99aa8bb75d8db515bb9c34654f95e647cda31987db7/adal-1.2.7-py2.py3-none-any.whl", hash = "sha256:2a7451ed7441ddbc57703042204a3e30ef747478eea022c70f789fc7f084bc3d", size = 55539, upload-time = "2021-04-05T16:33:39.544Z" },
-]
-
-[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -127,15 +112,16 @@ wheels = [
 
 [[package]]
 name = "azure-batch"
-version = "14.2.0"
+version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-common" },
-    { name = "msrestazure" },
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3e/4611960f8ceb281285d764f32a0e88515fab4e1e32ff5d02bc77e55bbcb6/azure-batch-14.2.0.tar.gz", hash = "sha256:c79267d6c3d3fe14a16a422ab5bbfabcbd68ed0b58b6bbcdfa0c8345c4c78532", size = 243784, upload-time = "2024-03-27T20:05:11.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/ec/9c38379dea2a4817a5c5b44282eff56476326cefa09da9e804809b397656/azure_batch-15.1.0.tar.gz", hash = "sha256:2f684d176b457b7213535e145180a914ed6844b2d1066fcc22ac88c3ac9e3fa5", size = 298104, upload-time = "2026-05-01T23:30:12.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/15/42aa83f62dc47e00bed0e590d19252c24b94b8c3b740d9bce33ec867e785/azure_batch-14.2.0-py3-none-any.whl", hash = "sha256:115ccff0007852784ccf8fc12f5f3d415ed80513be306da7a8938ca82d948ee7", size = 243322, upload-time = "2024-03-27T20:05:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/358a421ebbb0d6fa929333dd71b94922d34445aa02d9d2fa7c0a277dcf53/azure_batch-15.1.0-py3-none-any.whl", hash = "sha256:6001232ba67a4051f4f1b35d434232757b78baa14e4964ec3bfb91afa1d10ed4", size = 260933, upload-time = "2026-05-01T23:30:14.604Z" },
 ]
 
 [[package]]
@@ -391,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "cfa-dagster"
-version = "1.2.0"
+version = "1.3.2"
 source = { directory = "../" }
 dependencies = [
     { name = "aiofiles" },
@@ -407,7 +393,6 @@ dependencies = [
     { name = "dagster-graphql" },
     { name = "dagster-postgres" },
     { name = "dagster-shared" },
-    { name = "msrest" },
     { name = "psycopg2-binary" },
     { name = "pyyaml" },
 ]
@@ -416,12 +401,13 @@ dependencies = [
 dev = [
     { name = "dagster-dg-cli" },
     { name = "dagster-webserver" },
+    { name = "watchdog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = "~=24.1.0" },
-    { name = "azure-batch", specifier = "~=14.2.0" },
+    { name = "azure-batch", specifier = "~=15.1.0" },
     { name = "azure-identity", specifier = "~=1.25.1" },
     { name = "azure-keyvault-secrets" },
     { name = "azure-mgmt-appcontainers", specifier = "~=4.0.0" },
@@ -435,10 +421,10 @@ requires-dist = [
     { name = "dagster-postgres", specifier = "~=0.29.2" },
     { name = "dagster-shared", specifier = ">=1.12.2,<1.14" },
     { name = "dagster-webserver", marker = "extra == 'dev'", specifier = ">=1.12.2,<1.14" },
-    { name = "msrest", specifier = "~=0.7.1" },
     { name = "psycopg2-binary" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = "~=6.0.2" },
+    { name = "watchdog", marker = "extra == 'dev'", specifier = ">=6.0.0" },
 ]
 provides-extras = ["test", "dev"]
 
@@ -460,7 +446,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "azure-batch", specifier = "~=14.2.0" },
+    { name = "azure-batch", specifier = "~=15.1.0" },
     { name = "azure-identity", specifier = "~=1.25.0" },
     { name = "azure-mgmt-appcontainers", specifier = "~=4.0.0" },
     { name = "azure-mgmt-containerinstance", specifier = "~=10.1.0" },
@@ -960,6 +946,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -1257,20 +1244,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
-]
-
-[[package]]
-name = "msrestazure"
-version = "0.6.4.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "adal" },
-    { name = "msrest" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/86/06a086e4ed3523765a1917665257b1828f1bf882130768445f082a4c3484/msrestazure-0.6.4.post1.tar.gz", hash = "sha256:39842007569e8c77885ace5c46e4bf2a9108fcb09b1e6efdf85b6e2c642b55d4", size = 47728, upload-time = "2024-04-10T21:00:51.79Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/7e/620e883def84ae56b8a9da382d960f7f801e37518fe930085cf72c148dae/msrestazure-0.6.4.post1-py2.py3-none-any.whl", hash = "sha256:2264493b086c2a0a82ddf5fd87b35b3fffc443819127fed992ac5028354c151e", size = 40789, upload-time = "2024-04-10T21:00:49.359Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "pyyaml~=6.0.2",
     "azure-identity~=1.25.1",
-    "msrest~=0.7.1",
-    "azure-batch~=14.2.0",
+    "azure-batch~=15.1.0",
     "azure-mgmt-appcontainers~=4.0.0",
     "azure-mgmt-subscription~=3.1.1",
     "dagster-azure~=0.29.2",

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -357,8 +357,9 @@ class FilesystemADLS2IOManager(UPathIOManager):
         )
         effective_conflict = cast(
             OnInputConflict,
-            meta.on_input_conflict if meta and meta.on_input_conflict
-            else self._on_input_conflict
+            meta.on_input_conflict
+            if meta and meta.on_input_conflict
+            else self._on_input_conflict,
         )
         log.debug(f"effective_conflict: {effective_conflict}")
 

--- a/src/cfa_dagster/azure_batch/executor.py
+++ b/src/cfa_dagster/azure_batch/executor.py
@@ -7,20 +7,9 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Optional, cast
 
 import dagster._check as check
-from azure.batch import BatchServiceClient
-from azure.batch.models import (
-    AutoUserScope,
-    AutoUserSpecification,
-    BatchErrorException,
-    ComputeNodeIdentityReference,
-    ContainerRegistry,
-    ElevationLevel,
-    JobAddParameter,
-    PoolInformation,
-    TaskAddParameter,
-    TaskContainerSettings,
-    UserIdentity,
-)
+from azure.batch import BatchClient
+from azure.batch import models as batch_models
+from azure.core.exceptions import HttpResponseError
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.subscription import SubscriptionClient
 from dagster import Field, Permissive, StringSource, executor
@@ -45,7 +34,6 @@ from dagster_docker.utils import (
     validate_docker_config,
     validate_docker_image,
 )
-from msrest.authentication import BasicTokenAuthentication
 
 from ..utils import get_run_timestamp
 
@@ -181,25 +169,19 @@ class AzureBatchStepHandler(StepHandler):
         # self._pool_id = "cfa-dagster"
         self._pool_id = pool_name
         log.debug(f"Launching a new {self.name}")
-        credential_v2 = DefaultAzureCredential()
-        token = {
-            "access_token": credential_v2.get_token(
-                "https://batch.core.windows.net/.default"
-            ).token
-        }
-        credential_v1 = BasicTokenAuthentication(token)
+        credential = DefaultAzureCredential()
 
         batch_url = "https://cfaprdba.eastus.batch.azure.com"
 
         self._subscription_id = (
-            SubscriptionClient(credential_v2)
+            SubscriptionClient(credential)
             .subscriptions.list()
             .next()
             .subscription_id
         )
 
-        self._batch_client = BatchServiceClient(
-            credentials=credential_v1, batch_url=batch_url
+        self._batch_client = BatchClient(
+            endpoint=batch_url, credential=credential
         )
 
         self._image = check.opt_str_param(image, "image")
@@ -370,26 +352,26 @@ class AzureBatchStepHandler(StepHandler):
             return f"{PREFIX}{step_key}-{short_run_id}-{retry_str}"
 
     def _get_or_create_job(self, batch_client, job_id: str, pool_id: str):
-        pool_info = PoolInformation(pool_id=pool_id)
+        pool_info = batch_models.BatchPoolInfo(pool_id=pool_id)
 
-        job = JobAddParameter(
+        job = batch_models.BatchJobCreateOptions(
             id=job_id,
             pool_info=pool_info,
         )
 
         try:
-            batch_client.job.add(job)
+            batch_client.create_job(job=job)
             log.info(f"Created Batch job {job_id}")
-            return batch_client.job.get(job_id)
+            return batch_client.get_job(job_id=job_id)
 
-        except BatchErrorException as err:
+        except HttpResponseError as err:
             if err.error.code != "JobExists":
                 raise
 
             # Job was created by another thread/process
             log.debug(f"Batch job {job_id} already exists")
 
-            existing_job = batch_client.job.get(job_id)
+            existing_job = batch_client.get_job(job_id=job_id)
 
             # Should never happen since pool_id is factored into job_id hash
             if existing_job.pool_info.pool_id != pool_id:
@@ -429,9 +411,9 @@ class AzureBatchStepHandler(StepHandler):
         user_assigned_identity_name = "ext-edav-cfa-batch-account"
         resource_id = f"/subscriptions/{self._subscription_id}/resourceGroups/{resource_group_name}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{user_assigned_identity_name}"
 
-        container_registry = ContainerRegistry(
+        container_registry = batch_models.ContainerRegistryReference(
             registry_server="cfaprdbatchcr.azurecr.io",
-            identity_reference=ComputeNodeIdentityReference(
+            identity_reference=batch_models.BatchNodeIdentityReference(
                 resource_id=resource_id
             ),
         )
@@ -446,22 +428,22 @@ class AzureBatchStepHandler(StepHandler):
             "working_dir", "/app"
         )  # TODO: validate this
 
-        container_settings = TaskContainerSettings(
+        container_settings = batch_models.BatchTaskContainerSettings(
             image_name=step_image,
             container_run_options=f"--rm --workdir {workdir} {mount_options}",
             registry=container_registry,
         )
 
         # Run task as admin to be able to read/write to mounted drives
-        user_identity = UserIdentity(
-            auto_user=AutoUserSpecification(
-                scope=AutoUserScope.pool,
-                elevation_level=ElevationLevel.admin,
+        user_identity = batch_models.UserIdentity(
+            auto_user=batch_models.AutoUserSpecification(
+                scope=batch_models.AutoUserScope.pool,
+                elevation_level=batch_models.ElevationLevel.admin,
             )
         )
         task_id = self._get_task_id(step_handler_context)
 
-        task = TaskAddParameter(
+        task = batch_models.BatchTaskCreateOptions(
             id=task_id,
             command_line=" ".join(command),
             container_settings=container_settings,
@@ -471,7 +453,7 @@ class AzureBatchStepHandler(StepHandler):
             user_identity=user_identity,
         )
 
-        self._batch_client.task.add(job_id=job_id, task=task)
+        self._batch_client.create_task(job_id=job_id, task=task)
 
         yield DagsterEvent.step_worker_starting(
             step_handler_context.get_step_context(step_key),
@@ -491,7 +473,7 @@ class AzureBatchStepHandler(StepHandler):
         task_id = self._get_task_id(step_handler_context)
 
         try:
-            task = self._batch_client.task.get(job_id, task_id)
+            task = self._batch_client.get_task(job_id=job_id, task_id=task_id)
 
             # --- Check for explicit task failure info ---
             failure_details = None
@@ -532,7 +514,7 @@ class AzureBatchStepHandler(StepHandler):
                     )
                 )
 
-        except BatchErrorException as err:
+        except HttpResponseError as err:
             return CheckStepHealthResult.unhealthy(
                 reason=f"Error checking Azure Batch task status: {err}"
             )
@@ -544,7 +526,7 @@ class AzureBatchStepHandler(StepHandler):
         task_id = self._get_task_id(step_handler_context)
 
         try:
-            task = self._batch_client.task.get(job_id, task_id)
+            task = self._batch_client.get_task(job_id=job_id, task_id=task_id)
             if task.state in ("active", "preparing", "running"):
                 return CheckStepHealthResult.healthy()
             elif task.state == "completed":
@@ -558,7 +540,7 @@ class AzureBatchStepHandler(StepHandler):
                 return CheckStepHealthResult.unhealthy(
                     reason=f"Azure Batch task {task_id} in job {job_id} has unexpected state {task.state}."
                 )
-        except BatchErrorException as err:
+        except HttpResponseError as err:
             return CheckStepHealthResult.unhealthy(
                 reason=f"Error checking Azure Batch task status: {err}"
             )
@@ -575,4 +557,4 @@ class AzureBatchStepHandler(StepHandler):
             message=f"Terminating Azure Batch task {task_id} in job {job_id} for step {step_key}.",
             event_specific_data=EngineEventData(),
         )
-        self._batch_client.task.terminate(job_id=job_id, task_id=task_id)
+        self._batch_client.terminate_task(job_id=job_id, task_id=task_id)

--- a/src/cfa_dagster/dagster.yaml
+++ b/src/cfa_dagster/dagster.yaml
@@ -36,7 +36,9 @@ run_launcher:
 
 run_monitoring:
   enabled: true
-  max_resume_run_attempts: 1
+  # setting max_resume_run_attempts to > 0 will prevent compute cleanup on user termination
+  # https://github.com/dagster-io/dagster/issues/33923
+  max_resume_run_attempts: 0
 
 concurrency:
   default_op_concurrency_limit: 1000

--- a/src/cfa_dagster/hot_reload.py
+++ b/src/cfa_dagster/hot_reload.py
@@ -66,7 +66,10 @@ def _resolve_module_path(
         if candidate_file.is_file():
             return candidate_file.resolve()
         candidate_pkg = base / module_name
-        if candidate_pkg.is_dir() and (candidate_pkg / "__init__.py").is_file():
+        if (
+            candidate_pkg.is_dir()
+            and (candidate_pkg / "__init__.py").is_file()
+        ):
             return candidate_pkg.resolve()
 
     return None
@@ -105,9 +108,7 @@ def resolve_target_paths(
             elif module_path.is_file():
                 targets.add(module_path.resolve())
         else:
-            log.warning(
-                "Could not resolve root_module '%s'", root_module
-            )
+            log.warning("Could not resolve root_module '%s'", root_module)
 
     if not targets and entry_point:
         ep = Path(entry_point)
@@ -228,9 +229,7 @@ class HotReloader:
                 with self._lock:
                     if self._timer and self._timer.is_alive():
                         self._timer.cancel()
-                    self._timer = threading.Timer(
-                        debounce, callback
-                    )
+                    self._timer = threading.Timer(debounce, callback)
                     self._timer.daemon = True
                     self._timer.start()
 
@@ -241,24 +240,21 @@ class HotReloader:
                     _Handler(), str(path.parent), recursive=False
                 )
             else:
-                self._observer.schedule(
-                    _Handler(), str(path), recursive=True
-                )
+                self._observer.schedule(_Handler(), str(path), recursive=True)
 
         self._observer.daemon = True
         self._observer.start()
         if len(resolved) == 1 and resolved[0].is_file():
-            log.info(f"Hot-reloading: watching {resolved[0]}")
+            log.info(f"Hot-reloader: watching {resolved[0]}")
         elif all(p.is_file() for p in resolved):
             for p in resolved:
-                log.info(f"Hot-reloading: watching {p}")
+                log.info(f"Hot-reloader: watching {p}")
         else:
             dirs = sorted(
                 {str(p.parent if p.is_file() else p) for p in resolved}
             )
             log.info(
-                f"Hot-reloading: watching python files under "
-                f"{', '.join(dirs)}"
+                f"Hot-reloader: watching python files under {', '.join(dirs)}"
             )
 
     def stop(self):
@@ -272,7 +268,7 @@ class HotReloader:
             self._server_ready = wait_for_server(self._host, self._port)
             if not self._server_ready:
                 return
-        log.info("Hot-reloading: Change detected, reloading workspace...")
+        log.info("Hot-reloader: Change detected, reloading workspace...")
         reload_via_graphql(host=self._host, port=self._port)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,21 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "adal"
-version = "1.2.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyjwt" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/d7/a829bc5e8ff28f82f9e2dc9b363f3b7b9c1194766d5a75105e3885bfa9a8/adal-1.2.7.tar.gz", hash = "sha256:d74f45b81317454d96e982fd1c50e6fb5c99ac2223728aea8764433a39f566f1", size = 35196, upload-time = "2021-04-05T16:33:40.88Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/8d/58008a9a86075827f99aa8bb75d8db515bb9c34654f95e647cda31987db7/adal-1.2.7-py2.py3-none-any.whl", hash = "sha256:2a7451ed7441ddbc57703042204a3e30ef747478eea022c70f789fc7f084bc3d", size = 55539, upload-time = "2021-04-05T16:33:39.544Z" },
-]
-
-[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -139,15 +124,16 @@ wheels = [
 
 [[package]]
 name = "azure-batch"
-version = "14.2.0"
+version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-common" },
-    { name = "msrestazure" },
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3e/4611960f8ceb281285d764f32a0e88515fab4e1e32ff5d02bc77e55bbcb6/azure-batch-14.2.0.tar.gz", hash = "sha256:c79267d6c3d3fe14a16a422ab5bbfabcbd68ed0b58b6bbcdfa0c8345c4c78532", size = 243784, upload-time = "2024-03-27T20:05:11.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/ec/9c38379dea2a4817a5c5b44282eff56476326cefa09da9e804809b397656/azure_batch-15.1.0.tar.gz", hash = "sha256:2f684d176b457b7213535e145180a914ed6844b2d1066fcc22ac88c3ac9e3fa5", size = 298104, upload-time = "2026-05-01T23:30:12.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/15/42aa83f62dc47e00bed0e590d19252c24b94b8c3b740d9bce33ec867e785/azure_batch-14.2.0-py3-none-any.whl", hash = "sha256:115ccff0007852784ccf8fc12f5f3d415ed80513be306da7a8938ca82d948ee7", size = 243322, upload-time = "2024-03-27T20:05:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/358a421ebbb0d6fa929333dd71b94922d34445aa02d9d2fa7c0a277dcf53/azure_batch-15.1.0-py3-none-any.whl", hash = "sha256:6001232ba67a4051f4f1b35d434232757b78baa14e4964ec3bfb91afa1d10ed4", size = 260933, upload-time = "2026-05-01T23:30:14.604Z" },
 ]
 
 [[package]]
@@ -377,7 +363,6 @@ dependencies = [
     { name = "dagster-graphql" },
     { name = "dagster-postgres" },
     { name = "dagster-shared" },
-    { name = "msrest" },
     { name = "psycopg2-binary" },
     { name = "pyyaml" },
 ]
@@ -395,7 +380,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = "~=24.1.0" },
-    { name = "azure-batch", specifier = "~=14.2.0" },
+    { name = "azure-batch", specifier = "~=15.1.0" },
     { name = "azure-identity", specifier = "~=1.25.1" },
     { name = "azure-keyvault-secrets" },
     { name = "azure-mgmt-appcontainers", specifier = "~=4.0.0" },
@@ -409,7 +394,6 @@ requires-dist = [
     { name = "dagster-postgres", specifier = "~=0.29.2" },
     { name = "dagster-shared", specifier = ">=1.12.2,<1.14" },
     { name = "dagster-webserver", marker = "extra == 'dev'", specifier = ">=1.12.2,<1.14" },
-    { name = "msrest", specifier = "~=0.7.1" },
     { name = "psycopg2-binary" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = "~=6.0.2" },
@@ -1433,20 +1417,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
-]
-
-[[package]]
-name = "msrestazure"
-version = "0.6.4.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "adal" },
-    { name = "msrest" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/86/06a086e4ed3523765a1917665257b1828f1bf882130768445f082a4c3484/msrestazure-0.6.4.post1.tar.gz", hash = "sha256:39842007569e8c77885ace5c46e4bf2a9108fcb09b1e6efdf85b6e2c642b55d4", size = 47728, upload-time = "2024-04-10T21:00:51.79Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/7e/620e883def84ae56b8a9da382d960f7f801e37518fe930085cf72c148dae/msrestazure-0.6.4.post1-py2.py3-none-any.whl", hash = "sha256:2264493b086c2a0a82ddf5fd87b35b3fffc443819127fed992ac5028354c151e", size = 40789, upload-time = "2024-04-10T21:00:49.359Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #133

The main goal of this PR is to upgrade the azure-batch dependency from 14.2.0 to 15.1.0. This version introduced a number of breaking changes to the Azure Batch SDK which affects both the `infra/dagster_defs.py` workflows and the Azure Batch executor. 

To test this, I materialized an asset with the Batch executor, confirmed the Batch health checks still work, then confirmed the terminate functionality successfully terminates the Batch task.

I also ran the infra workflow that cleans up batch jobs and confirmed it was able to terminate old Batch jobs as well.
While testing, I discovered a bug in Dagster that prevents termination from cleaning up steps based on the dagster.yaml configuration so I changed the relevant property to work around the bug until the [fix](https://github.com/dagster-io/dagster/issues/33923) is merged