### PR TITLE
updating docs to flesh out concepts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 dev = [
     "mdx-truly-sane-lists>=1.3,<2",
     "zensical>=0.0.45",
+    "mkdocstrings[python]",
 ]
 
 [build-system]

--- a/src/cfa_dagster/dynamic_graph_asset.py
+++ b/src/cfa_dagster/dynamic_graph_asset.py
@@ -41,7 +41,7 @@ from .execution.utils import ExecutionConfig, SelectorConfig
 
 log = logging.getLogger(__name__)
 
-INTERNAL_CONFIG_IO_MANAGER = ADLS2PickleIOManager().get_resource_definition()
+_INTERNAL_CONFIG_IO_MANAGER = ADLS2PickleIOManager().get_resource_definition()
 
 
 class GraphAssetKwargs(TypedDict, total=False):
@@ -66,7 +66,7 @@ class GraphAssetKwargs(TypedDict, total=False):
 
 
 @dataclass
-class DimensionResourceInfo:
+class _DimensionResourceInfo:
     param_name: str
     resource_cls: type
     dimension_fields: list[str]
@@ -98,7 +98,7 @@ class GraphDimensionExclusion(dg.Config, Generic[T]):
 
 
 @dataclass
-class ExclusionResourceInfo:
+class _ExclusionResourceInfo:
     param_name: str
     resource_cls: type
     exclusion_fields: list[str]
@@ -118,8 +118,8 @@ def _get_resource_params(hints) -> dict[str, type]:
 
 def _get_dimension_resource_info(
     asset_name: str, resource_params: dict[str, type]
-) -> DimensionResourceInfo:
-    dimension_info: DimensionResourceInfo | None = None
+) -> _DimensionResourceInfo:
+    dimension_info: _DimensionResourceInfo | None = None
 
     for param_name, resource_cls in resource_params.items():
         resource_hints = get_type_hints(resource_cls)
@@ -138,7 +138,7 @@ def _get_dimension_resource_info(
                     f"Found: '{dimension_info.param_name}' and '{param_name}'. "
                     "Only one resource may contain GraphDimension fields."
                 )
-            dimension_info = DimensionResourceInfo(
+            dimension_info = _DimensionResourceInfo(
                 param_name=param_name,
                 resource_cls=resource_cls,
                 dimension_fields=dimension_fields,
@@ -159,8 +159,8 @@ def _get_exclusion_resource_info(
     asset_name: str,
     resource_params: dict[str, type],
     dimension_fields: list[str],
-) -> list[ExclusionResourceInfo]:
-    exclusion_infos: list[ExclusionResourceInfo] = []
+) -> list[_ExclusionResourceInfo]:
+    exclusion_infos: list[_ExclusionResourceInfo] = []
 
     for param_name, resource_cls in resource_params.items():
         resource_hints = get_type_hints(resource_cls)
@@ -185,7 +185,7 @@ def _get_exclusion_resource_info(
                 )
 
         exclusion_infos.append(
-            ExclusionResourceInfo(
+            _ExclusionResourceInfo(
                 param_name=param_name,
                 resource_cls=resource_cls,
                 exclusion_fields=exclusion_fields,
@@ -277,19 +277,19 @@ def _has_return_value(fn) -> bool:
 
 
 # using this causes the code location to crash when running multiple assets at once
-multiprocess_config = ExecutionConfig(
+_multiprocess_config = ExecutionConfig(
     executor=SelectorConfig(class_name="multiprocess_executor")
 )
-in_process_config = ExecutionConfig(
+_in_process_config = ExecutionConfig(
     executor=SelectorConfig(class_name="in_process_executor")
 )
 
 #  Choosing a lesser-used alpha char as a prefix to prevent Dagster/python keyword errors
 # DagsterInvalidDefinitionError: "in" is not a valid name in Dagster. It conflicts with a Dagster or python reserved keyword.
-SEGMENT_PREFIX = "x_"
+_SEGMENT_PREFIX = "x_"
 # Using triple underscore as a separator since a single underscore could be an
 # encoded character and a double underscore could be two consecutive encoded character
-SEGMENT_SEPARATOR = "___"
+_SEGMENT_SEPARATOR = "___"
 
 
 # -- Mapping key encoding --
@@ -300,12 +300,12 @@ def _encode_segment(value: str) -> str:
         lambda m: f"_{ord(m.group()):02X}_",
         str(value),
     )
-    return f"{SEGMENT_PREFIX}{encoded}"
+    return f"{_SEGMENT_PREFIX}{encoded}"
 
 
 def _decode_segment(encoded: str) -> str:
     """Decode _XX_ sequences back to original characters."""
-    encoded = encoded.removeprefix(SEGMENT_PREFIX)
+    encoded = encoded.removeprefix(_SEGMENT_PREFIX)
 
     return re.sub(
         r"_([0-9A-F]{2})_",
@@ -315,13 +315,13 @@ def _decode_segment(encoded: str) -> str:
 
 
 def _encode_mapping_key(values: tuple) -> str:
-    return SEGMENT_SEPARATOR.join(_encode_segment(v) for v in values)
+    return _SEGMENT_SEPARATOR.join(_encode_segment(v) for v in values)
 
 
 def _decode_mapping_key(mapping_key: str) -> list:
     return [
         _decode_segment(segment)
-        for segment in mapping_key.split(SEGMENT_SEPARATOR)
+        for segment in mapping_key.split(_SEGMENT_SEPARATOR)
     ]
 
 
@@ -361,7 +361,7 @@ def _in_to_asset_in(name: str, op_in: dg.In) -> dg.AssetIn:
     )
 
 
-def unpack_output(output) -> tuple[Any, dict]:
+def _unpack_output(output) -> tuple[Any, dict]:
     if isinstance(output, dg.Output):
         user_value = output.value
         user_metadata = output.metadata or {}
@@ -390,7 +390,7 @@ def _infer_ins(
 
 def _apply_graph_dimensions(
     context: dg.OpExecutionContext,
-    dimension_resource_info: DimensionResourceInfo,
+    dimension_resource_info: _DimensionResourceInfo,
     graph_dimensions: dict[str, str],
 ) -> Any:
     dimension_resource = getattr(
@@ -659,7 +659,7 @@ def dynamic_graph_asset(
                 ),
             },
             required_resource_keys=required_resource_keys,
-            tags=in_process_config.to_run_tags(),
+            tags=_in_process_config.to_run_tags(),
         )
         def gen_config(context, **kwargs):
             log.debug(f"kwargs: '{kwargs}'")
@@ -802,7 +802,7 @@ def dynamic_graph_asset(
                 result = next(result)
             log.debug(f"compute result: '{result}'")
             if should_return_all or is_first_dimension:
-                result, metadata = unpack_output(result)
+                result, metadata = _unpack_output(result)
 
                 # Merge our graph_dimensions metadata
                 merged_metadata = {
@@ -858,7 +858,7 @@ def dynamic_graph_asset(
                 if does_return_value
                 else {"out": dg.Out(dg.Nothing)}
             ),
-            tags=in_process_config.to_run_tags(),
+            tags=_in_process_config.to_run_tags(),
         )
         def output_op(context, **kwargs):
             compute_result = kwargs.get("compute_result")
@@ -871,7 +871,7 @@ def dynamic_graph_asset(
                 # handle sequences
                 result = result if should_return_all else result[0]
 
-                result, metadata = unpack_output(result)
+                result, metadata = _unpack_output(result)
 
                 # Merge our graph_dimensions metadata
                 merged_metadata = {
@@ -904,7 +904,7 @@ def dynamic_graph_asset(
         existing_resource_defs = graph_asset_kwargs.get("resource_defs") or {}
 
         merged_resource_defs = {
-            INTERNAL_CONFIG_IO_MANAGER_KEY: INTERNAL_CONFIG_IO_MANAGER,
+            INTERNAL_CONFIG_IO_MANAGER_KEY: _INTERNAL_CONFIG_IO_MANAGER,
             **existing_resource_defs,
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,7 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "mdx-truly-sane-lists" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "zensical" },
 ]
 
@@ -410,6 +411,7 @@ provides-extras = ["test", "dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mdx-truly-sane-lists", specifier = ">=1.3,<2" },
+    { name = "mkdocstrings", extras = ["python"] },
     { name = "zensical", specifier = ">=0.0.45" },
 ]
 
@@ -936,6 +938,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "github3-py"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1052,6 +1066,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
     { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -1408,6 +1431,104 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/27/16456314311abac2cedef4527679924e80ac4de19dd926699c1b261e0b9b/mdx_truly_sane_lists-1.3.tar.gz", hash = "sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45", size = 5359, upload-time = "2022-07-19T13:42:45.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/9e/dcd1027f7fd193aed152e01c6651a197c36b858f2cd1425ad04cb31a34fc/mdx_truly_sane_lists-1.3-py3-none-any.whl", hash = "sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37", size = 6071, upload-time = "2022-07-19T13:42:43.375Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -1823,6 +1944,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/cb/448649d7f25d228bf0be3a04590ab7afa77f15e056f8fa976ed05ec9a78f/pathlib_abc-0.5.2.tar.gz", hash = "sha256:fcd56f147234645e2c59c7ae22808b34c364bb231f685ddd9f96885aed78a94c", size = 33342, upload-time = "2025-10-10T18:37:20.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl", hash = "sha256:4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb", size = 19070, upload-time = "2025-10-10T18:37:19.437Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2309,6 +2439,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
     { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -1,0 +1,5 @@
+# API Reference
+
+::: cfa_dagster
+    options:
+        members: true

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -1,5 +1,7 @@
 # API Reference
 
+<!-- prettier-ignore-start -->
 ::: cfa_dagster
     options:
         members: true
+<!-- prettier-ignore-end -->

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -160,7 +160,7 @@ def daily_reports(context: dg.AssetExecutionContext):
 
 ## Dynamic Graph Assets
 
-[Dynamic graph assets](https://github.com/CDCgov/cfa-dagster/blob/main/src/cfa_dagster/dynamic_graph_asset.py) combine two existing Dagster concepts, [graph assets](https://docs.dagster.io/guides/build/assets/graph-backed-assets#defining-graph-backed-assets) and [dynamic outputs](https://docs.dagster.io/guides/build/ops/dynamic-graphs#a-dynamic-job), into one decorator to provide easy, runtime-configurable parallelism. Unlike normal Dagster partitions, dynamic graph assets allows you to parallelize logic against more than two dimensions.
+[Dynamic graph assets](../api.md#cfa_dagster.dynamic_graph_asset.dynamic_graph_asset) combine two existing Dagster concepts, [graph assets](https://docs.dagster.io/guides/build/assets/graph-backed-assets#defining-graph-backed-assets) and [dynamic outputs](https://docs.dagster.io/guides/build/ops/dynamic-graphs#a-dynamic-job), into one decorator to provide easy, runtime-configurable parallelism. Unlike normal Dagster partitions, dynamic graph assets allows you to parallelize logic against more than two dimensions.
 
 ```python
 

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -10,6 +10,14 @@ A Dagster [asset](https://docs.dagster.io/dagster-basics-tutorial/assets) is a p
 
 Once an asset is created, Dagster does not automatically run the code for the asset, it must be [materialized](https://docs.dagster.io/guides/build/assets/configuring-assets) first. When an asset is materialized, Dagster runs the asset’s function and creates the asset. When a materialization begins, it kicks off a run.
 
+```python
+
+@dg.asset()
+def meaning_of_life():
+  the_meaning = calculate_meaning_of_life()
+  return the_meaning  # 42
+```
+
 ## Resources
 
 A [resource](https://docs.dagster.io/dagster-basics-tutorial/resources#step-4-view-the-resource) in Dagster is something your assets need to do their work, but not the data you're producing. In the example of baking cookies, resources would be a mixing bowl, spoon, a baking sheet, and the oven.
@@ -25,9 +33,41 @@ Resources often represent:
 - I/O managers
 - Configuration dictionaries
 
+```python
+from dagster_azure.blob import (
+    AzureBlobStorageDefaultCredential,
+    AzureBlobStorageResource,
+)
+from cfa_dagster import ADLS2PickleIOManager
+
+class ParallelAssetConfig(dg.ConfigurableResource):
+    ingredient: GraphDimension[str] = GraphDimension(["sugar", "milk", "flour"])
+
+# Create Dagster definitions
+defs = dg.Definitions(
+    **collected_defs,
+    resources={
+        # This IOManager lets Dagster serialize asset outputs and store them
+        # in Azure to pass between assets
+        "io_manager": ADLS2PickleIOManager(),
+        # an example storage account
+        "azure_blob_storage": AzureBlobStorageResource(
+            account_url=f"{storage_account}.blob.core.windows.net",
+            credential=AzureBlobStorageDefaultCredential(),
+        ),
+        "parallel_asset_config": ParallelAssetConfig(),
+    },
+
+```
+
 ## Schedules
 
 [Schedules](https://docs.dagster.io/guides/automate/schedules) define a fixed time interval to run your pipeline. In the example of the cookies, this could be planning to bake the cookies at 1 pm.
+
+<!-- prettier-ignore-start -->
+!!! warning
+    When going to production, be mindful that sensors run in a constrained computing environment. See [Going to Production](./production.md#resource-constraints) for more details
+<!-- prettier-ignore-end -->
 
 ## Asset Jobs
 
@@ -37,18 +77,111 @@ Resources often represent:
 
 Each workflow (containing assets, resources or schedules) must be part of a [Definitions](https://docs.dagster.io/api/dagster/definitions#definitions) object. For CFA specifically, the definitions object is located within the [dagster_defs.py](https://github.com/CDCgov/cfa-dagster/blob/main/examples/dagster_defs.py) file. The `dagster_defs.py` file contains the Dagster-specific configurations, assets, jobs, and/or schedules in addition to the Definitions object.
 
+`cfa-dagster` exports a helper function to collect all the Dagster definitions in a file e.g.:
+
+```python
+from cfa_dagster import collect_definitions
+
+collected_defs = collect_definitions(globals())
+
+# Create Dagster definitions
+defs = dg.Definitions(
+    **collected_defs, # assets, asset checks, jobs, schedules, sensors
+    ... # other configuration like resources, executor, loggers, metadata, etc.
+)
+```
+
 ## Ops
 
 [Ops](https://docs.dagster.io/guides/build/ops) are single units of work in the pipeline. In the cookie example, an op could be getting the mixing bowl out, getting the flour from the pantry, or picking up the whisk before mixing the ingredients together. Dagster treats each op as a managed step, which allows the user to track whether the step succeeded or failed, record logs and metadata, retry failed steps, and visualize the pipeline in the Dagster UI.
 
+Use an `op` over an asset for tasks that don't produce tracked artifacts e.g.:
+
+```python
+@dg.op
+def build_image():
+  subprocess.run(["docker", "build", "-t", "my_image", "."], check=True)
+
+@dg.job()
+def build_image_job():
+  build_image()
+```
+
 ## Sensors
 
-[Sensors](https://docs.dagster.io/guides/automate/sensors#cursors-and-high-volume-events) check for events at regular time intervals, and if triggered, will start a job or other action. Sensors allow the workflow to run automatically without someone needing to manually start the pipeline. In the baking cookies example, this would be like having an assistant take the cookies out of the oven when the timer goes off.
+[Sensors](https://docs.dagster.io/guides/automate/sensors) check for events at regular time intervals, and if triggered, will start a job or other action. Sensors allow the workflow to run automatically without someone needing to manually start the pipeline. In the baking cookies example, this would be like having an assistant take the cookies out of the oven when the timer goes off.
+
+You might use a sensor to track external data sources e.g.:
+
+```python
+@dg.sensor(
+    job=my_job,
+    minimum_interval_seconds=5,
+    default_status=dg.DefaultSensorStatus.RUNNING,  # Sensor is turned on by default
+)
+def new_file_sensor():
+    new_files = check_for_new_files()
+    # New files, run `my_job`
+    if new_files:
+        for filename in new_files:
+            yield dg.RunRequest()
+    # No new files, skip the run and log the reason
+    else:
+        yield dg.SkipReason("No new files found")
+```
+
+<!-- prettier-ignore-start -->
+!!! warning
+    When going to production, be mindful that sensors run in a constrained computing environment. See [Going to Production](./production.md#resource-constraints) for more details
+<!-- prettier-ignore-end -->
 
 ## Partitions
 
 [Partitions](https://docs.dagster.io/guides/build/partitions-and-backfills/partitioning-ops#non-partitioned-job-with-date-config) divide the workflow into smaller pieces, which could speed up computation by using parallel processing. Users can test on an individual partition before trying to run larger ranges of data. In the cookie example, this could be scaling the recipe back to make 8 cookies instead of making the cookie dough for 80 cookies.
 
+Since partitions only allow you to run a workflow in parallel against two dimensions, you generally want to use a dynamic graph asset for parallelism instead. Time-based partitions are used most frequently to track asset outputs as they differ on a daily basis.
+
+```python
+# create a daily partition
+tz = "America/New_York"
+daily_partitions_def = dg.DailyPartitionsDefinition(
+    start_date=dt.datetime.now(ZoneInfo(tz)) - dt.timedelta(days=1),
+    end_offset=1,
+    timezone=tz,
+)
+
+@dg.asset(partitions_def=daily_partitions_def)
+def daily_reports(context: dg.AssetExecutionContext):
+  # daily partitions are represented as YYYY-mm-dd
+  report_date = context.partition_key
+  context.log.info(f"Generating a report for date: {report_date}")
+
+```
+
 ## Dynamic Graph Assets
 
-[Dynamic graph assets](https://github.com/CDCgov/cfa-dagster/blob/main/src/cfa_dagster/dynamic_graph_asset.py) were developed specifically for CFA Dagster workflows and were built on existing Dagster concepts. In standard Dagster, if you want an asset to run multiple times with different configurations, you typically use partitions. `@dynamic_graph_asset` allows you to run the same logic across multiple independent dimensions in parallel.
+[Dynamic graph assets](https://github.com/CDCgov/cfa-dagster/blob/main/src/cfa_dagster/dynamic_graph_asset.py) combine two existing Dagster concepts, [graph assets](https://docs.dagster.io/guides/build/assets/graph-backed-assets#defining-graph-backed-assets) and [dynamic outputs](https://docs.dagster.io/guides/build/ops/dynamic-graphs#a-dynamic-job), into one decorator to provide easy, runtime-configurable parallelism. Unlike normal Dagster partitions, dynamic graph assets allows you to parallelize logic against more than two dimensions.
+
+```python
+
+class ParallelAssetConfig(dg.ConfigurableResource):
+    ingredient: GraphDimension[str] = GraphDimension(["sugar", "milk", "flour"])
+
+
+@dynamic_graph_asset(
+    description="A parallel asset that runs R code for different diseases",
+)
+def parallel_asset(
+    context: dg.OpExecutionContext,
+    parallel_asset_config: ParallelAssetConfig,
+):
+    ingredient = parallel_asset_config.ingredient.current_value
+    context.log.info(f"Running for ingredient: {ingredient}")
+
+defs = dg.Definitions(
+    **collected_defs,
+    resources={
+        "parallel_asset_config": ParallelAssetConfig(),
+    },
+)
+```

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,18 +1,114 @@
 # Using Dagster in a Project
 
+## Requirements
+
 - **Python:** Dagster supports Python 3.10 - 3.13 (3.13 recommended).
 - **Package manager:** To manage the python packages, we recommend [uv](https://docs.astral.sh/uv/) which Dagster uses internally.
 - **Git:** Refer to the [Git documentation](https://github.com/git-guides/install-git) if you don’t have this installed.
 
-## Install Dagster
+## Python projects
 
-1. Activate your Python [virtual environment](https://docs.python.org/3/library/venv.html)
-2. [Install Dagster with uv:](https://docs.dagster.io/getting-started/installation#installation-requirements-for-manually-creating-or-updating-a-project)
-   `uv add dagster dagster-webserver dagster-dg-cli`.
-3. Clone the [`cfa-dagster` repository](https://github.com/CDCgov/cfa-dagster/tree/main):
-   `git clone https://github.com/CDCgov/cfa-dagster.git`
-   Or
-   `gh repo clone cdcgov/cfa-dagster`
+To add Dagster to an existing python project, add a `dagster_defs.py` file to the root of your repo. You can add dependencies to the `pyproject.toml` like so:
+
+```toml
+[project]
+name = "my-project"
+requires-python = ">=3.13,<3.14"
+
+# include cfa-dagster which bundles all other Dagster dependencies
+dependencies = [
+    "cfa-dagster",
+]
+
+# include cfa-dagster's dev dependencies like the dg cli and dagster websever
+[dependency-groups]
+dev = [
+  "cfa-dagster[dev]",
+]
+
+# configure your dagster_defs.py file as a dagster project
+# to allow use of the `dg` cli
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "dagster_defs"
+defs_module = "dagster_defs"
+code_location_target_module = "dagster_defs"
+```
+
+If your workflow uses Docker or Azure, you can include Dagster in your `Dockerfile` like so:
+
+```docker
+ARG WORKDIR=/app
+
+# set an explicit workdir
+WORKDIR ${WORKDIR}
+
+# Dependency information
+COPY pyproject.toml ./pyproject.toml
+COPY uv.lock ./uv.lock
+
+# Set VIRTUAL_ENV variable at runtime
+ENV VIRTUAL_ENV=/cfa-stf-routine-forecasting/.venv
+
+# Create the virtual environment
+RUN uv venv "${VIRTUAL_ENV}"
+
+# Update PATH to use the selected venv at runtime
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+
+# Sync all python dependencies excluding dev dependencies to minimize image size
+RUN uv sync --no-dev
+```
+
+## Non-python projects
+
+If your repo does not use python or you do not want a `pyproject.toml` for other reasons, using Dagster is as easy as including a `dagster_defs.py` file in the root of your repo. With the `uv` package manager, you can include dependencies directly in the file:
+
+```python
+#!/usr/bin/env -S uv run --script
+# PEP 723 dependency definition: https://peps.python.org/pep-0723/
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = [
+#    "cfa-dagster[dev] @ git+https://github.com/cdcgov/cfa-dagster.git",
+# ]
+# ///
+import dagster as dg
+from cfa_dagster import (
+   start_dev_env,
+...
+<remaining python code below>
+```
+
+If your workflow uses Docker or Azure, you can include Dagster in your `Dockerfile` like so:
+
+```docker
+
+# add Dagster workflow file
+ARG WORKDIR=/app
+
+# set an explicit workdir
+WORKDIR ${WORKDIR}
+
+# copy the Dagster definitions into the image
+COPY ./dagster_defs.py .
+
+# remove dev dependencies before install
+RUN sed -i 's/cfa-dagster\[[^]]*\]/cfa-dagster/' dagster_defs.py
+
+# create a virtual environment for the Dagster workflows
+ENV VIRTUAL_ENV=${WORKDIR}/.venv
+RUN uv venv ${VIRTUAL_ENV}
+
+# install the Dagster workflow dependencies
+RUN uv sync --script dagster_defs.py --active
+
+# add the Dagster workflow dependencies to the system path
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+
+```
 
 ## Using the Dagster CLI
 
@@ -23,36 +119,28 @@ The [Dagster CLI](https://docs.dagster.io/api/clis/dg-cli/dg-cli-reference) is a
 - Debug issues — export or import run artifacts for troubleshooting.
 - Validate definitions — check your Dagster code for errors before running.
 - Manage deployments — list deployments, filter runs by deployment, and view branch-specific logs.
-- Authenticate and configure — log in to your Dagster+ deployment, switch profiles, and store credentials securely.
+- Authenticate and configure — log in to your Dagster+ deployment, switch profiles, and store credentials securely. (not relevant for `cfa-dagster` users)
 
-Instructions for installing and configuring the Dagster CLI from the Dagster official documentation can be found [here](https://docs.dagster.io/api/clis/dg-cli/dg-cli-configuration).
+Dagster currently offers several CLIs for interacting with your definitions from the command line. Some of the actions require configuration, which `cfa-dagster` provides by re-exporting Dagster's CLIs with a `cfa-` prefix:
 
-### Running the `cfa-dagster` CLI
+### The `dg` CLI (`cfa-dg`)
 
-1. Activate your virtual environment (`venv`)
-2. Add `cfa-dagster` to `pyproject.toml`
+The `dg` CLI can be used to:
 
-```toml
- dependencies = [
-    "cfa-dagster @ git+https://github.com/cdcgov/cfa-dagster.git",
- ]
-```
+- Run a local dev server: `cfa-dg dev`
+- Create and manage runs: `cfa-dg launch --asset my_asset`
+- Validate definitions: `dg check defs`
+- See more at the [docs](https://docs.dagster.io/api/clis/dg-cli/dg-cli-reference)
 
-3. `uv sync`
-4. Run `cfa-dg dev`
+### The `dagster-webserver` CLI (`cfa-dagster-webserver`)
 
-## Update your Dockerfile
+The `dagster-webserver` CLI can be used to run the Dagster websever against a set of definitions without running the background daemon processes. This is useful when you want to browse the Dagster run history without interfering with live runs. By providing a `DAGSTER_USER` environment variable, you can browse the run history of another user e.g.:
 
-After your virtual environment is activated in your Dockerfile, add the following code:
+- `DAGSTER_USER=ap82 cfa-dagster-webserver`: view the run history for Giovanni Rella
+- `DAGSTER_USER=github_actions cfa-dagster-webserver`: view the run history for Dagster runs launched in GitHub actions
 
-```dockerfile
-# add Dagster workflow file
-COPY ./dagster_defs.py .
+See more at the [docs](https://docs.dagster.io/api/clis/cli#dagster-webserver)
 
-# install the dagster workflow dependencies
-RUN uv sync --script dagster_defs.py --active
-```
+### the `dagster` CLI (`cfa-dagster`)
 
-## Logging in with Azure
-
-You will need to log in with Azure, so check out the [Predict Handbook Site](https://potential-adventure-637em36.pages.github.io/azure/AzureBasics-login_methods.html#primary-login-methods) for details on how to do so.
+The `dagster` CLI has been superseded `dg` CLI in most user-facing cases. `cfa-dagster` uses it under the hood to host the code locations. Docs are available [here](https://docs.dagster.io/api/clis/cli)

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -6,7 +6,7 @@ This basic example should help you get up and running with local Dagster develop
 
 To get started with local Dagster development, clone the [`cfa-dagster` repository](https://github.com/CDCgov/cfa-dagster/tree/main) and check out the [examples](examples/). Running the example will automatically install the necessary dependencies into a virtual environment and activate it.
 
-1. Now that you've cloned the repo and have entered the `examples/` directory, start the Dagster UI by running `uv run dagster_defs.py` and clicking the link in your terminal (usually http://127.0.0.1:4000/)
+1. Now that you've cloned the repo and have entered the `examples/` directory, start the Dagster UI by running `uv run dagster_defs.py` and clicking the link in your terminal (<http://127.0.0.1:4000/> by default)
 2. Build your image by navigating to the [build_image_job](http://127.0.0.1:4000/locations/dagster_defs.py/jobs/build_image_job/playground) and clicking `Launch Run` in the bottom right
 3. Materialize an asset!
 
@@ -16,7 +16,7 @@ To get started with local Dagster development, clone the [`cfa-dagster` reposito
 
 ## Next steps
 
-- Try materializing partitioned_r_asset
+- Try materializing `partitioned_r_asset`
 - Try materializing multiple assets at once
 - Try materializing your Asset on Azure Container App Jobs
 

--- a/website/docs/tutorial/azure.md
+++ b/website/docs/tutorial/azure.md
@@ -26,6 +26,23 @@ azure_caj_config = ExecutionConfig(
 2. Locate the `defs = dg.Definitions...` object towards the bottom of the `dagster_defs.py` file.
 3. Set the `default_config` for the `dynamic_executor` to be `azure_caj_config`.
 
+```python
+# Create Dagster definitions
+defs = dg.Definitions(
+    **collected_defs,
+    executor=dynamic_executor(
+        default_config=azure_caj_config,
+        # alternate configs show you default values in the Launchpad on hover
+        alternate_configs=[
+            default_config,
+            docker_config,
+            azure_caj_config,
+            azure_batch_config,
+        ],
+    ),
+)
+```
+
 ## Azure Batch
 
 To run the container in Azure Batch,
@@ -59,3 +76,20 @@ azure_batch_config = ExecutionConfig(
 
 2. Locate the `defs = dg.Definitions...` object towards the bottom of the `dagster_defs.py` file.
 3. Set the `default_config` for the `dynamic_executor` to be `azure_batch_config`.
+
+```python
+# Create Dagster definitions
+defs = dg.Definitions(
+    **collected_defs,
+    executor=dynamic_executor(
+        default_config=azure_batch_config,
+        # alternate configs show you default values in the Launchpad on hover
+        alternate_configs=[
+            default_config,
+            docker_config,
+            azure_caj_config,
+            azure_batch_config,
+        ],
+    ),
+)
+```

--- a/website/docs/tutorial/docker.md
+++ b/website/docs/tutorial/docker.md
@@ -33,3 +33,20 @@ docker_config = ExecutionConfig(
 
 2. Locate the `defs = dg.Definitions...` object towards the bottom of the `dagster_defs.py` file.
 3. Set the `default_config` for the `dynamic_executor` to be `docker_config`.
+
+```python
+# Create Dagster definitions
+defs = dg.Definitions(
+    **collected_defs,
+    executor=dynamic_executor(
+        default_config=docker_config,
+        # alternate configs show you default values in the Launchpad on hover
+        alternate_configs=[
+            default_config,
+            docker_config,
+            azure_caj_config,
+            azure_batch_config,
+        ],
+    ),
+)
+```

--- a/website/docs/tutorial/image.md
+++ b/website/docs/tutorial/image.md
@@ -136,8 +136,10 @@ Click on the Launchpad tab, which is next to the Overview tab above the `build_i
 
 <img src="image_3.png" alt="Dagster UI job launchpad" width="75%" height="75%">
 
+<!-- prettier-ignore-start -->
 !!! tip
-Any time you modify a configuration, click on the “Refresh config” button above the code box. Dagster will tell you if your configuration file needs to be refreshed.
+    Any time you modify a configuration, click on the “Refresh config” button above the code box. Dagster will tell you if your configuration file needs to be refreshed.
+<!-- prettier-ignore-end -->
 
 When you are ready to run your job, click on the “Launch Run” button on the bottom right-hand corner of the screen. While your job is running, you can see the logs printed out in real time at the bottom of the screen.
 

--- a/website/zensical.toml
+++ b/website/zensical.toml
@@ -37,25 +37,25 @@ watch = [ "includes" ]
 [project.plugins.mkdocstrings.handlers.python]
 inventories = ["https://docs.python.org/3/objects.inv"]
 paths = [".."]
-options = {
-  docstring_style = "google",
-  inherited_members = true,
-  # we probably don't want to inline the source code for brevity
-  show_source = false,
-  show_signature = true,
-  show_signature_annotations = true,
-  show_root_heading = true,
-  # required to show dataclass attributes
-  show_attributes = true,
-  members = true,
-  show_labels = true,
-  # required to show dataclasses under submodules
-  show_if_no_docstring = true,
-  # required to show dynamic_graph_asset
-  show_submodules = true,
-  # filter out anything starting with _, or log, or T, but allow __init__
-  filters = ["!^_", "!^log$", "!^T$", "__init__"],
-}
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+inherited_members = true
+# we probably don't want to inline the source code for brevity
+show_source = false
+show_signature = true
+show_signature_annotations = true
+show_root_heading = true
+# required to show dataclass attributes
+show_attributes = true
+members = true
+show_labels = true
+# required to show dataclasses under submodules
+show_if_no_docstring = true
+# required to show dynamic_graph_asset
+show_submodules = true
+# filter out anything starting with _, or log, or T, but allow __init__
+filters = ["!^_", "!^log$", "!^T$", "__init__"]
 
 [project.theme]
 

--- a/website/zensical.toml
+++ b/website/zensical.toml
@@ -25,10 +25,37 @@ nav = [
       "examples/county-rt.md",
       "examples/nssp-etl.md",
       "examples/stf-forecasting.md"
+    ] },
+    { "API" = [
+        "api.md"
     ] }
+
 ]
 
 watch = [ "includes" ]
+
+[project.plugins.mkdocstrings.handlers.python]
+inventories = ["https://docs.python.org/3/objects.inv"]
+paths = [".."]
+options = {
+  docstring_style = "google",
+  inherited_members = true,
+  # we probably don't want to inline the source code for brevity
+  show_source = false,
+  show_signature = true,
+  show_signature_annotations = true,
+  show_root_heading = true,
+  # required to show dataclass attributes
+  show_attributes = true,
+  members = true,
+  show_labels = true,
+  # required to show dataclasses under submodules
+  show_if_no_docstring = true,
+  # required to show dynamic_graph_asset
+  show_submodules = true,
+  # filter out anything starting with _, or log, or T, but allow __init__
+  filters = ["!^_", "!^log$", "!^T$", "__init__"],
+}
 
 [project.theme]
 
@@ -57,10 +84,9 @@ features = [
     "toc.integrate",
 ]
 
+
 [project.markdown_extensions.toc]
 permalink = true
-
-[project.plugins.offline]
 
 [[project.theme.palette]]
 scheme = "slate"


### PR DESCRIPTION
I added some example usage to the concepts and updated the installation page with instructions for python and non-python projects.
A tip, I had to add `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` to prevent `prettier` from removing the 4 spaces that delineate an admonition block

EDIT: I was playing around some more and I got zensical to auto-generate API docs. This is useful because now we can link the Dynamic Graph Asset on the concepts page to the API reference