### PR TITLE
Flexible definitions file location(s); `dagster_defs.py` no longer a requirement

### DIFF
--- a/infra/dagster_defs.py
+++ b/infra/dagster_defs.py
@@ -229,7 +229,7 @@ def create_or_update_code_location_aca(
                             "memory": "1Gi",
                         },
                         "command": [
-                            "dagster",
+                            "cfa-dagster",
                             "code-server",
                             "start",
                             "-h",
@@ -244,6 +244,10 @@ def create_or_update_code_location_aca(
                         "env": [
                             {"name": "DAGSTER_USER", "value": "prod"},
                             {"name": "CFA_DAGSTER_ENV", "value": "prod"},
+                            {
+                                "name": "CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE",
+                                "value": "true",
+                            },
                             {"name": "DEPLOY_DATE", "value": deploy_date},
                             {
                                 "name": "AZURE_CLIENT_ID",

--- a/src/cfa_dagster/hot_reload.py
+++ b/src/cfa_dagster/hot_reload.py
@@ -1,4 +1,3 @@
-import importlib.util
 import logging
 import threading
 import time
@@ -7,15 +6,10 @@ from typing import TYPE_CHECKING, Optional
 
 from dagster_graphql import DagsterGraphQLClient
 
-from .utils import find_pyproject_toml
+from .utils import get_dg_project_config, resolve_project_module_path
 
 if TYPE_CHECKING:
     from watchdog.observers import Observer
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore[no-redef]
 
 log = logging.getLogger(__name__)
 
@@ -30,51 +24,6 @@ mutation ReloadWorkspace {
 """
 
 
-def _read_root_module(pyproject_path: Path) -> Optional[str]:
-    try:
-        with open(pyproject_path, "rb") as f:
-            data = tomllib.load(f)
-        return (
-            data.get("tool", {})
-            .get("dg", {})
-            .get("project", {})
-            .get("root_module")
-        )
-    except Exception:
-        return None
-
-
-def _resolve_module_path(
-    module_name: str,
-    search_dir: Optional[Path] = None,
-) -> Optional[Path]:
-    try:
-        spec = importlib.util.find_spec(module_name)
-        if spec is not None:
-            if spec.submodule_search_locations:
-                pkg_dir = list(spec.submodule_search_locations)[0]
-                return Path(pkg_dir)
-            if spec.origin and spec.origin.endswith(".py"):
-                return Path(spec.origin).resolve()
-    except (ImportError, ValueError, AttributeError):
-        pass
-
-    for base in [search_dir, Path.cwd()] if search_dir else [Path.cwd()]:
-        if base is None:
-            continue
-        candidate_file = (base / module_name).with_suffix(".py")
-        if candidate_file.is_file():
-            return candidate_file.resolve()
-        candidate_pkg = base / module_name
-        if (
-            candidate_pkg.is_dir()
-            and (candidate_pkg / "__init__.py").is_file()
-        ):
-            return candidate_pkg.resolve()
-
-    return None
-
-
 def _collect_py_files(directory: Path) -> list[Path]:
     if not directory.is_dir():
         return []
@@ -87,23 +36,16 @@ def resolve_target_paths(
 ) -> list[Path]:
     targets: set[Path] = set()
 
-    if entry_point:
-        ep = Path(entry_point)
-        if ep.is_file():
-            targets.add(ep.resolve())
-            # if the entry point is a file, we just need to watch that file
-            return sorted(targets)
-
-    pyproj = (
-        Path(pyproject_path)
+    config = (
+        get_dg_project_config(Path(pyproject_path).parent)
         if pyproject_path
-        else find_pyproject_toml(Path.cwd())
+        else get_dg_project_config(Path.cwd())
     )
-    root_module = _read_root_module(pyproj) if pyproj else None
+    pyproj, project_config = config if config else (None, {})
+    root_module = project_config.get("root_module")
 
-    if root_module:
-        search_dir = pyproj.parent if pyproj else None
-        module_path = _resolve_module_path(root_module, search_dir=search_dir)
+    if pyproj and root_module:
+        module_path = resolve_project_module_path(pyproj, root_module)
         if module_path:
             if module_path.is_dir():
                 targets.update(_collect_py_files(module_path))
@@ -111,6 +53,11 @@ def resolve_target_paths(
                 targets.add(module_path.resolve())
         else:
             log.warning("Could not resolve root_module '%s'", root_module)
+
+    if not targets and entry_point:
+        ep = Path(entry_point)
+        if ep.is_file():
+            targets.add(ep.resolve())
 
     return sorted(targets)
 

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -177,32 +177,80 @@ def find_pyproject_toml(start_dir: Path) -> Optional[Path]:
     return None
 
 
+def get_defs_target(
+    start_dir: Optional[Path] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Return ``(defs_file, defs_module)`` resolved from ``[tool.dg]`` metadata
+    in ``pyproject.toml``.
+
+    At most one of the two is non-None:
+    - ``defs_file`` is set when ``[tool.dg.project].defs_module`` resolves to
+      an existing ``.py`` file
+    - ``defs_module`` is set when ``[tool.dg.project].defs_module`` is a
+      module
+    - both are None when there is no ``[tool.dg]`` metadata
+    """
+    pyproj = find_pyproject_toml(start_dir or Path.cwd())
+    if not pyproj:
+        return (None, None)
+    try:
+        data = tomllib.loads(pyproj.read_text())
+        dg_config = data.get("tool", {}).get("dg", {})
+        if dg_config.get("directory_type") not in ("project", "workspace"):
+            return (None, None)
+        defs_module = dg_config.get("project", {}).get("defs_module")
+        if not defs_module:
+            return (None, None)
+        proj_defs_file = (pyproj.parent / defs_module).with_suffix(".py")
+        if proj_defs_file.is_file():
+            return (str(proj_defs_file), None)
+        return (None, defs_module)
+    except Exception:
+        log.debug(
+            "Unable to read [tool.dg] metadata from pyproject.toml",
+            exc_info=True,
+        )
+        return (None, None)
+
+
 def check_needs_fallback_file() -> Optional[str]:
     """
     Return the name of the fallback file if:
     1. The user provides a file instead of module in the pyproject.toml for [tool.dg.project.defs_module]
     2. The user doesn't have [tool.dg.project] in the pyproject.toml
     """
-    pyproj = find_pyproject_toml(Path.cwd())
-    if pyproj:
-        try:
-            data = tomllib.loads(pyproj.read_text())
-            dg_config = data.get("tool", {}).get("dg", {})
-            if dg_config.get("directory_type") in ("project", "workspace"):
-                proj_config = dg_config.get("project", {})
-                defs_module = proj_config.get("defs_module")
-                if defs_module:
-                    proj_defs_file = Path(defs_module).with_suffix(".py")
-                    # if they provided a file, return the file
-                    if proj_defs_file.is_file():
-                        log.debug(f"Provided defs file: {proj_defs_file}")
-                        return str(proj_defs_file)
-                    # if they didn't provide a file, assume it is a valid module and return None
-                    else:
-                        return None
-        except Exception:
-            pass
+    defs_file, defs_module = get_defs_target()
+    if defs_file:
+        log.debug(f"Provided defs file: {defs_file}")
+        return defs_file
+    if defs_module:
+        # a valid module is configured, no fallback needed
+        return None
     return DEFAULT_DEFS_FILE
+
+
+def resolve_code_server_target_args(
+    start_dir: Optional[Path] = None,
+) -> list[str]:
+    """
+    Return the python pointer args for `dagster code-server start`.
+
+    Uses ``pyproject.toml`` metadata when available:
+    - ``[tool.dg.project].defs_module`` that resolves to an existing ``.py``
+      file returns ``["-f", <file>]``
+    - ``[tool.dg.project].defs_module`` that is a module returns
+      ``["-m", <module>]``
+    - otherwise falls back to ``["-f", DEFAULT_DEFS_FILE]``
+    """
+    defs_file, defs_module = get_defs_target(start_dir)
+    if defs_file:
+        log.debug(f"Using defs file: {defs_file}")
+        return ["-f", defs_file]
+    if defs_module:
+        log.debug(f"Using defs module: {defs_module}")
+        return ["-m", defs_module]
+    return ["-f", DEFAULT_DEFS_FILE]
 
 
 def _get_flag_value(args: list[str], *flags: str) -> str | None:
@@ -256,7 +304,21 @@ def _run_cli(
         port = LOCAL_PORT
     log.debug(f"args: {args}")
 
-    if first_subcommand in ("dev", "launch") or add_fallback:
+    if first_subcommand == "code-server":
+        has_target = (
+            "-f" in args
+            or "--python-file" in args
+            or "-m" in args
+            or "--module-name" in args
+        )
+        if not has_target:
+            target_args = resolve_code_server_target_args()
+            log.info(
+                "Resolved code-server target args from pyproject.toml: %s",
+                target_args,
+            )
+            args = [*args, *target_args]
+    elif first_subcommand in ("dev", "launch") or add_fallback:
         fallback = defs_file or check_needs_fallback_file()
         if fallback and "-f" not in args and "--python-file" not in args:
             defs_file = fallback
@@ -312,7 +374,9 @@ def run_dagster():
     _run_cli(cli, ENV_PREFIX)
 
 
-def run_dg(argv: list[str] | None = None, defs_file: Optional[str] = None):
+def run_dg(
+    argv: Optional[list[str]] | None = None, defs_file: Optional[str] = None
+):
     """
     Wrapper for the `dg` cli
     """
@@ -340,7 +404,7 @@ def start_dev_env(caller_name: str):
     # Start the Dagster UI and set necessary env vars if
     # called directly via `uv run dagster_defs.py` or `python dagster_defs.py`
     if caller_name == "__main__":
-        defs_file = Path(sys.argv[0]).name
+        defs_file = sys.argv[0]
         log.debug(f"defs_file: {defs_file}")
         run_dg(argv=[None, "dev", *sys.argv[1:]], defs_file=defs_file)
 

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -31,6 +31,7 @@ log = logging.getLogger(__name__)
 LOCAL_HOSTNAME = "127.0.0.1"
 LOCAL_PORT = 4000
 DEFAULT_DEFS_FILE = "dagster_defs.py"
+ALLOW_DEFAULT_DEFS_OVERRIDE_ENV = "CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE"
 PROD_HOSTNAME = os.getenv(
     "DAGSTER_WEBSERVER_URL", "dagster.apps.edav.ext.cdc.gov"
 )
@@ -376,6 +377,39 @@ def _has_target(args: list[str]) -> bool:
     )
 
 
+def _replace_default_defs_target(
+    args: list[str],
+) -> tuple[list[str], str | None]:
+    """
+    Function to override the -f dagster_defs.py flag that is passed by `dagster code-server start`
+    This can be removed once all code locations are using cfa-dagster >= 1.4.4
+    """
+    next_args = list(args)
+    for i, arg in enumerate(next_args[:-1]):
+        if arg not in ("-f", "--python-file"):
+            continue
+        if next_args[i + 1] != DEFAULT_DEFS_FILE:
+            continue
+        try:
+            defs_file = resolve_defs_file()
+        except Exception:
+            log.debug(
+                "Unable to resolve definitions file; keeping %s",
+                DEFAULT_DEFS_FILE,
+                exc_info=True,
+            )
+            return next_args, DEFAULT_DEFS_FILE
+        if defs_file != DEFAULT_DEFS_FILE:
+            log.info(
+                "Replacing default definitions file %s with %s",
+                DEFAULT_DEFS_FILE,
+                defs_file,
+            )
+            next_args[i + 1] = defs_file
+        return next_args, next_args[i + 1]
+    return next_args, None
+
+
 def _run_cli(
     cli,
     env_prefix: str,
@@ -410,6 +444,17 @@ def _run_cli(
         host = LOCAL_HOSTNAME
         port = LOCAL_PORT
     log.debug(f"args: {args}")
+
+    # need to explicitly pass the -f flag for code locations that don't have
+    # the fallback behavior for dagster code-server start yet
+    # using an env var to override the -f flag with the fallback behavior
+    # for code locations that have the latest cfa-dagster code
+    if (
+        first_subcommand == "code-server"
+        and os.getenv(ALLOW_DEFAULT_DEFS_OVERRIDE_ENV) == "true"
+    ):
+        args, replaced_defs_file = _replace_default_defs_target(args)
+        defs_file = replaced_defs_file or defs_file
 
     if (
         first_subcommand in ("dev", "launch", "code-server")

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -1,4 +1,5 @@
 import importlib.resources
+import importlib.util
 import logging
 import os
 import sys
@@ -179,78 +180,135 @@ def find_pyproject_toml(start_dir: Path) -> Optional[Path]:
 
 def get_defs_target(
     start_dir: Optional[Path] = None,
-) -> tuple[Optional[str], Optional[str]]:
+) -> Optional[str]:
     """
-    Return ``(defs_file, defs_module)`` resolved from ``[tool.dg]`` metadata
-    in ``pyproject.toml``.
+    Return the concrete definitions file resolved from ``[tool.dg]`` metadata
+    in ``pyproject.toml``, or None when there is no ``[tool.dg]`` metadata.
 
-    At most one of the two is non-None:
-    - ``defs_file`` is set when ``[tool.dg.project].defs_module`` resolves to
-      an existing ``.py`` file
-    - ``defs_module`` is set when ``[tool.dg.project].defs_module`` is a
-      module
-    - both are None when there is no ``[tool.dg]`` metadata
+    The dotted ``defs_module`` is converted to a relative ``.py`` path and
+    checked against two layouts:
+
+    - flat/package layout, e.g.::
+
+          [tool.dg.project]
+          root_module = "some_module"
+          defs_module = "some_module.dagster_defs"
+
+      checks ``pyproj_parent/some_module/dagster_defs.py``
+
+    - src layout, which additionally checks under ``src/``, e.g.::
+
+          [tool.dg.project]
+          root_module = "dagster_defs"
+          defs_module = "dagster_defs"
+
+      checks ``pyproj_parent/dagster_defs.py`` and
+      ``pyproj_parent/src/dagster_defs.py``
+
+    When ``defs_module`` is omitted, dagster's default of
+    ``<root_module>.definitions`` is used, e.g.::
+
+          [tool.dg.project]
+          root_module = "some_module"
+
+      checks ``pyproj_parent/some_module/definitions.py`` and
+      ``pyproj_parent/src/some_module/definitions.py``.
+
+    Raises
+    ------
+    RuntimeError
+        If ``[tool.dg]`` metadata is configured but cannot be resolved to a
+        concrete ``.py`` file.
     """
     pyproj = find_pyproject_toml(start_dir or Path.cwd())
     if not pyproj:
-        return (None, None)
+        return None
     try:
         data = tomllib.loads(pyproj.read_text())
         dg_config = data.get("tool", {}).get("dg", {})
         if dg_config.get("directory_type") not in ("project", "workspace"):
-            return (None, None)
+            return None
         defs_module = dg_config.get("project", {}).get("defs_module")
-        if not defs_module:
-            return (None, None)
-        proj_defs_file = (pyproj.parent / defs_module).with_suffix(".py")
-        if proj_defs_file.is_file():
-            return (str(proj_defs_file), None)
-        return (None, defs_module)
+        root_module = dg_config.get("project", {}).get("root_module")
+        if not root_module:
+            return None
+        # dagster's default when no defs_module is configured is
+        # <root_module>.definitions, e.g. src/<root_module>/definitions.py
+        defs_module = defs_module or f"{root_module}.definitions"
+
+        module_parts = defs_module.split(".")
+        rel_path = Path(*module_parts[:-1], f"{module_parts[-1]}.py")
+        for base_dir in (pyproj.parent, pyproj.parent / "src"):
+            proj_defs_file = base_dir / rel_path
+            log.debug(f"proj_defs_file: {proj_defs_file}")
+            if proj_defs_file.is_file():
+                return str(proj_defs_file)
+
+        module_file = _module_to_defs_file(defs_module)
+        if module_file:
+            log.debug(
+                f"Resolved configured module '{defs_module}' to file:"
+                f" {module_file}"
+            )
+            return module_file
+        raise RuntimeError(
+            f"Configured defs module '{defs_module}' does not resolve to an"
+            " existing .py file and is not importable in this environment."
+            " A definitions file is required to launch."
+        )
+    except RuntimeError:
+        raise
     except Exception:
         log.debug(
             "Unable to read [tool.dg] metadata from pyproject.toml",
             exc_info=True,
         )
-        return (None, None)
-
-
-def check_needs_fallback_file() -> Optional[str]:
-    """
-    Return the name of the fallback file if:
-    1. The user provides a file instead of module in the pyproject.toml for [tool.dg.project.defs_module]
-    2. The user doesn't have [tool.dg.project] in the pyproject.toml
-    """
-    defs_file, defs_module = get_defs_target()
-    if defs_file:
-        log.debug(f"Provided defs file: {defs_file}")
-        return defs_file
-    if defs_module:
-        # a valid module is configured, no fallback needed
         return None
-    return DEFAULT_DEFS_FILE
 
 
-def resolve_code_server_target_args(
-    start_dir: Optional[Path] = None,
-) -> list[str]:
+def _module_to_defs_file(module_name: str) -> str | None:
     """
-    Return the python pointer args for `dagster code-server start`.
-
-    Uses ``pyproject.toml`` metadata when available:
-    - ``[tool.dg.project].defs_module`` that resolves to an existing ``.py``
-      file returns ``["-f", <file>]``
-    - ``[tool.dg.project].defs_module`` that is a module returns
-      ``["-m", <module>]``
-    - otherwise falls back to ``["-f", DEFAULT_DEFS_FILE]``
+    Return the on-disk ``.py`` file backing ``module_name``, or None when
+    the module is not importable, is a namespace package, or its origin
+    is not a regular file (e.g. inside a zip archive).
     """
-    defs_file, defs_module = get_defs_target(start_dir)
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ValueError):
+        return None
+    if not spec or not spec.origin:
+        return None
+    origin = Path(spec.origin)
+    if not origin.is_file():
+        return None
+    return str(origin)
+
+
+def resolve_defs_file(start_dir: Path | None = None) -> str:
+    """
+    Resolve a concrete definitions file path to launch with.
+
+    Remote executors require launching against a definitions file, so this
+    always returns a path. Resolution order:
+
+    1. A ``[tool.dg.project]`` defs target that resolves to an existing
+       ``.py`` file on disk relative to ``pyproject.toml``
+    2. A configured module that is importable, resolved to its on-disk
+       file via :func:`importlib.util.find_spec`
+    3. ``DEFAULT_DEFS_FILE`` when there is no ``[tool.dg]`` metadata
+
+    Raises
+    ------
+    RuntimeError
+        If ``[tool.dg]`` metadata is configured but neither the defs file
+        nor the module can be resolved, since silently loading the default
+        definitions could launch the wrong code.
+    """
+    defs_file = get_defs_target(start_dir)
     if defs_file:
-        log.debug(f"Using defs file: {defs_file}")
-        return ["-f", defs_file]
-    if defs_module:
-        log.debug(f"Using defs module: {defs_module}")
-        return ["-m", defs_module]
-    return ["-f", DEFAULT_DEFS_FILE]
+        log.debug(f"Resolved defs file from pyproject.toml: {defs_file}")
+        return defs_file
+    return DEFAULT_DEFS_FILE
 
 
 def _get_flag_value(args: list[str], *flags: str) -> str | None:
@@ -270,17 +328,32 @@ def _add_host_port(args: list[str]) -> list[str]:
     return [*args, *extra]
 
 
+def _has_target(args: list[str]) -> bool:
+    return any(
+        flag in args
+        for flag in (
+            "-f",
+            "--python-file",
+            "-m",
+            "--module-name",
+            "-w",
+            "--workspace",
+        )
+    )
+
+
 def _run_cli(
     cli,
     env_prefix: str,
     argv: list[str] | None = None,
     defs_file: Optional[str] = None,
     always_add_host_port: bool = False,
-    add_fallback: bool = False,
+    add_defs_file_if_missing: bool = False,
 ):
     """
-    Runs a cli tool, automatically falling back to ``-f defs_file`` when
-    running ``dev`` outside a dagster project directory.
+    Runs a cli tool, resolving a definitions file via
+    :func:`resolve_defs_file` and launching with ``-f <file>`` when no
+    python file target is provided.
     """
     set_env_vars()
     configure_dev_db()
@@ -304,25 +377,13 @@ def _run_cli(
         port = LOCAL_PORT
     log.debug(f"args: {args}")
 
-    if first_subcommand == "code-server":
-        has_target = (
-            "-f" in args
-            or "--python-file" in args
-            or "-m" in args
-            or "--module-name" in args
-        )
-        if not has_target:
-            target_args = resolve_code_server_target_args()
-            log.info(
-                "Resolved code-server target args from pyproject.toml: %s",
-                target_args,
-            )
-            args = [*args, *target_args]
-    elif first_subcommand in ("dev", "launch") or add_fallback:
-        fallback = defs_file or check_needs_fallback_file()
-        if fallback and "-f" not in args and "--python-file" not in args:
-            defs_file = fallback
-            log.info(f"No dagster project found, using -f {defs_file}")
+    if (
+        first_subcommand in ("dev", "launch", "code-server")
+        or add_defs_file_if_missing
+    ):
+        if not _has_target(args):
+            defs_file = defs_file or resolve_defs_file()
+            log.info(f"Using definitions file: {defs_file}")
             args = [*args, "-f", defs_file]
 
     if first_subcommand == "dev" and defs_file:
@@ -361,7 +422,7 @@ def run_dagster_webserver():
         cli,
         "DAGSTER_WEBSERVER",
         always_add_host_port=True,
-        add_fallback=True,
+        add_defs_file_if_missing=True,
     )
 
 

--- a/src/cfa_dagster/utils.py
+++ b/src/cfa_dagster/utils.py
@@ -5,7 +5,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import quote
 
 import dagster as dg
@@ -178,12 +178,75 @@ def find_pyproject_toml(start_dir: Path) -> Optional[Path]:
     return None
 
 
+def get_dg_project_config(
+    start_dir: Optional[Path] = None,
+) -> tuple[Path, dict[str, Any]] | None:
+    pyproj = find_pyproject_toml(start_dir or Path.cwd())
+    if not pyproj:
+        return None
+    try:
+        data = tomllib.loads(pyproj.read_text())
+    except Exception:
+        log.debug(
+            "Unable to read [tool.dg] metadata from pyproject.toml",
+            exc_info=True,
+        )
+        return None
+
+    dg_config = data.get("tool", {}).get("dg", {})
+    if dg_config.get("directory_type") not in ("project", "workspace"):
+        return None
+
+    project_config = dg_config.get("project", {})
+    if not isinstance(project_config, dict):
+        return None
+    return pyproj, project_config
+
+
+def resolve_project_module_path(
+    pyproject_path: Path,
+    module_name: str,
+) -> Path | None:
+    module_parts = module_name.split(".")
+    module_path = Path(*module_parts)
+    module_file = Path(*module_parts[:-1], f"{module_parts[-1]}.py")
+
+    for base_dir in (pyproject_path.parent, pyproject_path.parent / "src"):
+        candidate_file = base_dir / module_file
+        log.debug(f"candidate_file: {candidate_file}")
+        if candidate_file.is_file():
+            return candidate_file.resolve()
+
+        candidate_pkg = base_dir / module_path
+        log.debug(f"candidate_pkg: {candidate_pkg}")
+        if (
+            candidate_pkg.is_dir()
+            and (candidate_pkg / "__init__.py").is_file()
+        ):
+            return candidate_pkg.resolve()
+
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ValueError):
+        return None
+    if not spec:
+        return None
+    if spec.submodule_search_locations:
+        return Path(list(spec.submodule_search_locations)[0]).resolve()
+    if spec.origin:
+        origin = Path(spec.origin)
+        if origin.is_file():
+            return origin.resolve()
+    return None
+
+
 def get_defs_target(
     start_dir: Optional[Path] = None,
 ) -> Optional[str]:
     """
-    Return the concrete definitions file resolved from ``[tool.dg]`` metadata
-    in ``pyproject.toml``, or None when there is no ``[tool.dg]`` metadata.
+    Return the definitions file resolved from ``[tool.dg]`` metadata in
+    ``pyproject.toml`` relative to the project root, or None when there is no
+    ``[tool.dg]`` metadata.
 
     The dotted ``defs_module`` is converted to a relative ``.py`` path and
     checked against two layouts:
@@ -220,37 +283,26 @@ def get_defs_target(
         If ``[tool.dg]`` metadata is configured but cannot be resolved to a
         concrete ``.py`` file.
     """
-    pyproj = find_pyproject_toml(start_dir or Path.cwd())
-    if not pyproj:
+    config = get_dg_project_config(start_dir)
+    if not config:
         return None
+    pyproj, project_config = config
     try:
-        data = tomllib.loads(pyproj.read_text())
-        dg_config = data.get("tool", {}).get("dg", {})
-        if dg_config.get("directory_type") not in ("project", "workspace"):
-            return None
-        defs_module = dg_config.get("project", {}).get("defs_module")
-        root_module = dg_config.get("project", {}).get("root_module")
+        defs_module = project_config.get("defs_module")
+        root_module = project_config.get("root_module")
         if not root_module:
             return None
         # dagster's default when no defs_module is configured is
         # <root_module>.definitions, e.g. src/<root_module>/definitions.py
         defs_module = defs_module or f"{root_module}.definitions"
 
-        module_parts = defs_module.split(".")
-        rel_path = Path(*module_parts[:-1], f"{module_parts[-1]}.py")
-        for base_dir in (pyproj.parent, pyproj.parent / "src"):
-            proj_defs_file = base_dir / rel_path
-            log.debug(f"proj_defs_file: {proj_defs_file}")
-            if proj_defs_file.is_file():
-                return str(proj_defs_file)
-
-        module_file = _module_to_defs_file(defs_module)
-        if module_file:
+        module_path = resolve_project_module_path(pyproj, defs_module)
+        if module_path and module_path.is_file():
             log.debug(
                 f"Resolved configured module '{defs_module}' to file:"
-                f" {module_file}"
+                f" {module_path}"
             )
-            return module_file
+            return os.path.relpath(module_path, pyproj.parent)
         raise RuntimeError(
             f"Configured defs module '{defs_module}' does not resolve to an"
             " existing .py file and is not importable in this environment."
@@ -264,24 +316,6 @@ def get_defs_target(
             exc_info=True,
         )
         return None
-
-
-def _module_to_defs_file(module_name: str) -> str | None:
-    """
-    Return the on-disk ``.py`` file backing ``module_name``, or None when
-    the module is not importable, is a namespace package, or its origin
-    is not a regular file (e.g. inside a zip archive).
-    """
-    try:
-        spec = importlib.util.find_spec(module_name)
-    except (ImportError, ValueError):
-        return None
-    if not spec or not spec.origin:
-        return None
-    origin = Path(spec.origin)
-    if not origin.is_file():
-        return None
-    return str(origin)
 
 
 def resolve_defs_file(start_dir: Path | None = None) -> str:

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -1,0 +1,68 @@
+from cfa_dagster.hot_reload import resolve_target_paths
+
+
+def test_resolve_target_paths_watches_src_root_module(tmp_path):
+    project_dir = tmp_path / "project"
+    package_dir = project_dir / "src" / "cfa_epinow2_pipeline"
+    package_dir.mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text(
+        """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "cfa_epinow2_pipeline"
+defs_module = "cfa_epinow2_pipeline.dg_defs"
+code_location_target_module = "cfa_epinow2_pipeline.dg_defs"
+"""
+    )
+    init_file = package_dir / "__init__.py"
+    defs_file = package_dir / "dg_defs.py"
+    asset_file = package_dir / "assets.py"
+    init_file.write_text("")
+    defs_file.write_text("defs = None\n")
+    asset_file.write_text("assets = []\n")
+
+    paths = resolve_target_paths(
+        entry_point=defs_file,
+        pyproject_path=project_dir / "pyproject.toml",
+    )
+
+    assert paths == sorted(
+        [init_file.resolve(), asset_file.resolve(), defs_file.resolve()]
+    )
+
+
+def test_resolve_target_paths_watches_flat_root_module(tmp_path):
+    project_dir = tmp_path / "project"
+    package_dir = project_dir / "my_project"
+    package_dir.mkdir(parents=True)
+    (project_dir / "pyproject.toml").write_text(
+        """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "my_project"
+"""
+    )
+    init_file = package_dir / "__init__.py"
+    defs_file = package_dir / "definitions.py"
+    init_file.write_text("")
+    defs_file.write_text("defs = None\n")
+
+    paths = resolve_target_paths(
+        entry_point=defs_file,
+        pyproject_path=project_dir / "pyproject.toml",
+    )
+
+    assert paths == sorted([init_file.resolve(), defs_file.resolve()])
+
+
+def test_resolve_target_paths_falls_back_to_entry_point(tmp_path):
+    defs_file = tmp_path / "dagster_defs.py"
+    defs_file.write_text("defs = None\n")
+
+    paths = resolve_target_paths(entry_point=defs_file)
+
+    assert paths == [defs_file.resolve()]

--- a/tests/test_run_launcher.py
+++ b/tests/test_run_launcher.py
@@ -95,7 +95,7 @@ def test_get_launcher_config_from_run_config():
             config = launcher._get_launcher_config(run, None)
 
     assert config.launcher.class_name == "DefaultRunLauncher"
-    assert config.executor.class_name == "in_process_executor"
+    assert config.executor is None
 
 
 def test_get_launcher_config_from_run_tags():
@@ -148,23 +148,25 @@ def test_get_launcher_config_from_metadata():
 
     # Mock the _get_location_metadata method to return execution config in metadata
     # Also mock the default config to avoid validation issues
-    with patch.object(
-        launcher,
-        "_get_location_metadata",
-        return_value={
-            "cfa_dagster/execution": Mock(
-                value={
-                    "launcher": {
-                        "DefaultRunLauncher": {}
-                    },  # Changed to avoid validation issues
-                    "executor": {
-                        "in_process_executor": {}
-                    },  # Changed to avoid validation issues
-                }
-            )
-        },
-    ):
-        with patch(
+    with (
+        patch.object(launcher, "_get_execution_config", return_value=None),
+        patch.object(
+            launcher,
+            "_get_location_metadata",
+            return_value={
+                "cfa_dagster/execution": Mock(
+                    value={
+                        "launcher": {
+                            "DefaultRunLauncher": {}
+                        },  # Changed to avoid validation issues
+                        "executor": {
+                            "in_process_executor": {}
+                        },  # Changed to avoid validation issues
+                    }
+                )
+            },
+        ),
+        patch(
             "cfa_dagster.execution.run_launcher.ExecutionConfig.default",
             return_value=ExecutionConfig(
                 launcher=SelectorConfig(
@@ -174,11 +176,12 @@ def test_get_launcher_config_from_metadata():
                     class_name="in_process_executor", config={}
                 ),
             ),
-        ):
-            config = launcher._get_launcher_config(run, context)
+        ),
+    ):
+        config = launcher._get_launcher_config(run, context)
 
     assert config.launcher.class_name == "DefaultRunLauncher"
-    assert config.executor.class_name == "in_process_executor"
+    assert config.executor is None
 
 
 def test_create_launcher_default_dev():
@@ -501,21 +504,23 @@ def test_hierarchy_precedence_level_3_metadata():
 
     # Mock the _get_location_metadata method to return execution config in metadata
     # Also mock the default config to avoid validation issues
-    with patch.object(
-        launcher,
-        "_get_location_metadata",
-        return_value={
-            "cfa_dagster/execution": Mock(
-                value={
-                    "launcher": {
-                        "DefaultRunLauncher": {}
-                    },  # Changed to avoid validation issues
-                    "executor": {"in_process_executor": {}},
-                }
-            )
-        },
-    ):
-        with patch(
+    with (
+        patch.object(launcher, "_get_execution_config", return_value=None),
+        patch.object(
+            launcher,
+            "_get_location_metadata",
+            return_value={
+                "cfa_dagster/execution": Mock(
+                    value={
+                        "launcher": {
+                            "DefaultRunLauncher": {}
+                        },  # Changed to avoid validation issues
+                        "executor": {"in_process_executor": {}},
+                    }
+                )
+            },
+        ),
+        patch(
             "cfa_dagster.execution.run_launcher.ExecutionConfig.default",
             return_value=ExecutionConfig(
                 launcher=SelectorConfig(
@@ -525,12 +530,13 @@ def test_hierarchy_precedence_level_3_metadata():
                     class_name="in_process_executor", config={}
                 ),
             ),
-        ):
-            config = launcher._get_launcher_config(run, context)
+        ),
+    ):
+        config = launcher._get_launcher_config(run, context)
 
     # Metadata should take precedence when run config and tags are absent
     assert config.launcher.class_name == "DefaultRunLauncher"
-    assert config.executor.class_name == "in_process_executor"
+    assert config.executor is None
 
 
 def test_hierarchy_precedence_level_4_legacy_tags():
@@ -555,16 +561,18 @@ def test_hierarchy_precedence_level_4_legacy_tags():
 
     # Mock the _get_location_metadata method to return only legacy launcher metadata
     # Also mock the default config to avoid validation issues
-    with patch.object(
-        launcher,
-        "_get_location_metadata",
-        return_value={
-            "cfa_dagster/launcher": Mock(
-                value={"class": "DefaultRunLauncher", "config": {}}
-            )
-        },
-    ):
-        with patch(
+    with (
+        patch.object(launcher, "_get_execution_config", return_value=None),
+        patch.object(
+            launcher,
+            "_get_location_metadata",
+            return_value={
+                "cfa_dagster/launcher": Mock(
+                    value={"class": "DefaultRunLauncher", "config": {}}
+                )
+            },
+        ),
+        patch(
             "cfa_dagster.execution.run_launcher.ExecutionConfig.default",
             return_value=ExecutionConfig(
                 launcher=SelectorConfig(
@@ -574,8 +582,9 @@ def test_hierarchy_precedence_level_4_legacy_tags():
                     class_name="in_process_executor", config={}
                 ),
             ),
-        ):
-            config = launcher._get_launcher_config(run, context)
+        ),
+    ):
+        config = launcher._get_launcher_config(run, context)
 
     # Legacy tags should take precedence when higher levels are absent
     assert config.launcher.class_name == "DefaultRunLauncher"
@@ -597,19 +606,21 @@ def test_hierarchy_precedence_level_5_legacy_metadata():
 
     # Mock the _get_location_metadata method to return only legacy launcher metadata
     # Also mock the default config to avoid validation issues
-    with patch.object(
-        launcher,
-        "_get_location_metadata",
-        return_value={
-            "cfa_dagster/launcher": Mock(
-                value={
-                    "class": "DefaultRunLauncher",
-                    "config": {},  # Removed param to avoid validation issues
-                }
-            )
-        },
-    ):
-        with patch(
+    with (
+        patch.object(launcher, "_get_execution_config", return_value=None),
+        patch.object(
+            launcher,
+            "_get_location_metadata",
+            return_value={
+                "cfa_dagster/launcher": Mock(
+                    value={
+                        "class": "DefaultRunLauncher",
+                        "config": {},  # Removed param to avoid validation issues
+                    }
+                )
+            },
+        ),
+        patch(
             "cfa_dagster.execution.run_launcher.ExecutionConfig.default",
             return_value=ExecutionConfig(
                 launcher=SelectorConfig(
@@ -619,8 +630,9 @@ def test_hierarchy_precedence_level_5_legacy_metadata():
                     class_name="in_process_executor", config={}
                 ),
             ),
-        ):
-            config = launcher._get_launcher_config(run, context)
+        ),
+    ):
+        config = launcher._get_launcher_config(run, context)
 
     # Legacy metadata should take precedence when all other levels are absent
     assert config.launcher.class_name == "DefaultRunLauncher"
@@ -630,7 +642,8 @@ def test_partial_config_filling():
     """Test that missing launcher/executor are filled from lower priority sources"""
     launcher = DynamicRunLauncher()
 
-    # Create a run with partial config (only executor in run config, launcher in tags)
+    # Create a run with partial config (executor in run config is intentionally
+    # ignored; launcher is resolved from tags)
     run = Mock(spec=DagsterRun)
     run.run_config = {
         "execution": {
@@ -681,6 +694,6 @@ def test_partial_config_filling():
         ):
             config = launcher._get_launcher_config(run, context)
 
-    # Should combine launcher from tags and executor from run config
+    # Should use launcher from tags and leave executor unset.
     assert config.launcher.class_name == "DefaultRunLauncher"
-    assert config.executor.class_name == "in_process_executor"
+    assert config.executor is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,12 @@ from dagster import MetadataValue
 from dagster_shared.check.functions import CheckError
 
 from cfa_dagster.execution.utils import ExecutionConfig, SelectorConfig
-from cfa_dagster.utils import _run_cli
+from cfa_dagster.utils import (
+    DEFAULT_DEFS_FILE,
+    _run_cli,
+    get_defs_target,
+    resolve_defs_file,
+)
 
 
 def test_selector_config_from_run_config():
@@ -373,3 +378,319 @@ def test_run_cli_click_abort():
         with pytest.raises(SystemExit) as excinfo:
             _run_cli(mock_cli, "TEST", argv=["prog", "subcommand"])
         assert excinfo.value.code == 0
+
+
+FLAT_LAYOUT_TOML = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "dagster_defs"
+defs_module = "dagster_defs"
+code_location_target_module = "dagster_defs"
+"""
+
+DOTTED_MODULE_TOML = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "cfa_epinow2_pipeline"
+defs_module = "cfa_epinow2_pipeline.dg_defs"
+code_location_target_module = "cfa_epinow2_pipeline.dg_defs"
+"""
+
+DEFAULT_DEFS_TOML = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "my_project"
+"""
+
+
+def make_project_dir(
+    tmp_path,
+    dg_toml="",
+    defs_relpaths=(),
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(exist_ok=True)
+    (project_dir / "pyproject.toml").write_text(dg_toml)
+    for relpath in defs_relpaths:
+        defs_file = project_dir / relpath
+        defs_file.parent.mkdir(parents=True, exist_ok=True)
+        defs_file.write_text("defs = None\n")
+    return project_dir
+
+
+def test_get_defs_target_flat_layout(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path, FLAT_LAYOUT_TOML, ["dagster_defs.py"]
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    assert defs_file == str(project_dir / "dagster_defs.py")
+
+
+def test_get_defs_target_package_layout_dotted_module(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path,
+        DOTTED_MODULE_TOML,
+        ["cfa_epinow2_pipeline/dg_defs.py"],
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    expected = project_dir / "cfa_epinow2_pipeline" / "dg_defs.py"
+    assert defs_file == str(expected)
+
+
+def test_get_defs_target_src_layout_dotted_module(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path,
+        DOTTED_MODULE_TOML,
+        ["src/cfa_epinow2_pipeline/dg_defs.py"],
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    expected = project_dir / "src" / "cfa_epinow2_pipeline" / "dg_defs.py"
+    assert defs_file == str(expected)
+
+
+def test_get_defs_target_prefers_flat_over_src_layout(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path,
+        DOTTED_MODULE_TOML,
+        [
+            "cfa_epinow2_pipeline/dg_defs.py",
+            "src/cfa_epinow2_pipeline/dg_defs.py",
+        ],
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    expected = project_dir / "cfa_epinow2_pipeline" / "dg_defs.py"
+    assert defs_file == str(expected)
+
+
+def test_get_defs_target_raises_when_no_file_or_importable_module(tmp_path):
+    project_dir = make_project_dir(tmp_path, DOTTED_MODULE_TOML)
+
+    with pytest.raises(RuntimeError, match="cfa_epinow2_pipeline.dg_defs"):
+        get_defs_target(project_dir)
+
+
+def test_get_defs_target_default_definitions_src_layout(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path, DEFAULT_DEFS_TOML, ["src/my_project/definitions.py"]
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    assert defs_file == str(
+        project_dir / "src" / "my_project" / "definitions.py"
+    )
+
+
+def test_get_defs_target_default_definitions_flat_layout(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path, DEFAULT_DEFS_TOML, ["my_project/definitions.py"]
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    assert defs_file == str(project_dir / "my_project" / "definitions.py")
+
+
+def test_get_defs_target_default_definitions_raises_when_unresolvable(tmp_path):
+    project_dir = make_project_dir(tmp_path, DEFAULT_DEFS_TOML)
+
+    with pytest.raises(RuntimeError, match="my_project.definitions"):
+        get_defs_target(project_dir)
+
+
+def test_get_defs_target_explicit_defs_module_beats_default(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path,
+        DEFAULT_DEFS_TOML.replace(
+            'root_module = "my_project"',
+            'root_module = "my_project"\n'
+            'defs_module = "my_project.custom_defs"',
+        ),
+        ["my_project/custom_defs.py", "my_project/definitions.py"],
+    )
+
+    defs_file = get_defs_target(project_dir)
+
+    expected = project_dir / "my_project" / "custom_defs.py"
+    assert defs_file == str(expected)
+
+
+def test_get_defs_target_no_tool_dg_metadata(tmp_path):
+    project_dir = make_project_dir(tmp_path, '[project]\nname = "x"\n')
+
+    defs_file = get_defs_target(project_dir)
+
+    assert defs_file is None
+
+
+def test_get_defs_target_missing_root_and_defs_modules(tmp_path):
+    toml = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+code_location_target_module = "dagster_defs"
+"""
+    project_dir = make_project_dir(tmp_path, toml, ["dagster_defs.py"])
+
+    defs_file = get_defs_target(project_dir)
+
+    assert defs_file is None
+
+
+MODULE_ONLY_TOML = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "fake_pipeline"
+defs_module = "fake_pipeline.dg_defs"
+"""
+
+
+def test_resolve_defs_file_returns_configured_file(tmp_path):
+    project_dir = make_project_dir(
+        tmp_path, FLAT_LAYOUT_TOML, ["dagster_defs.py"]
+    )
+
+    assert resolve_defs_file(project_dir) == str(
+        project_dir / "dagster_defs.py"
+    )
+
+
+def test_resolve_defs_file_resolves_importable_module(tmp_path, monkeypatch):
+    toml = MODULE_ONLY_TOML.replace("fake_pipeline", "fake_pipeline_resolve")
+    modules_dir = tmp_path / "modules"
+    package_dir = modules_dir / "fake_pipeline_resolve"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "dg_defs.py").write_text("defs = None\n")
+    monkeypatch.syspath_prepend(str(modules_dir))
+
+    project_dir = make_project_dir(tmp_path, toml)
+
+    assert resolve_defs_file(project_dir) == str(package_dir / "dg_defs.py")
+
+
+def test_get_defs_target_resolves_importable_module(tmp_path, monkeypatch):
+    toml = MODULE_ONLY_TOML.replace("fake_pipeline", "fake_pipeline_target")
+    modules_dir = tmp_path / "modules"
+    package_dir = modules_dir / "fake_pipeline_target"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "dg_defs.py").write_text("defs = None\n")
+    monkeypatch.syspath_prepend(str(modules_dir))
+
+    project_dir = make_project_dir(tmp_path, toml)
+
+    assert get_defs_target(project_dir) == str(package_dir / "dg_defs.py")
+
+
+def test_resolve_defs_file_raises_when_unresolvable(tmp_path):
+    unresolvable_toml = """
+[tool.dg]
+directory_type = "project"
+
+[tool.dg.project]
+root_module = "no_such_package_12345"
+defs_module = "no_such_package_12345.defs"
+"""
+    project_dir = make_project_dir(tmp_path, unresolvable_toml)
+
+    with pytest.raises(RuntimeError, match="no_such_package_12345"):
+        resolve_defs_file(project_dir)
+
+
+def test_resolve_defs_file_defaults_without_tool_dg_metadata(tmp_path):
+    project_dir = make_project_dir(tmp_path, '[project]\nname = "x"\n')
+
+    assert resolve_defs_file(project_dir) == DEFAULT_DEFS_FILE
+
+
+def test_run_cli_appends_resolved_defs_file_for_launch():
+    mock_cli = Mock()
+    with (
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch(
+            "cfa_dagster.utils.resolve_defs_file",
+            return_value="/tmp/fake_defs.py",
+        ),
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "launch"],
+            add_defs_file_if_missing=True,
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert args[-2:] == ["-f", "/tmp/fake_defs.py"]
+
+
+def test_run_cli_appends_resolved_defs_file_for_code_server():
+    mock_cli = Mock()
+    with (
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch(
+            "cfa_dagster.utils.resolve_defs_file",
+            return_value="/tmp/fake_defs.py",
+        ),
+    ):
+        _run_cli(mock_cli, "TEST", argv=["prog", "code-server", "start"])
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert args[-2:] == ["-f", "/tmp/fake_defs.py"]
+
+
+def test_run_cli_does_not_append_defs_file_with_workspace():
+    mock_cli = Mock()
+    with (
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch("cfa_dagster.utils.resolve_defs_file") as resolve_defs_file_mock,
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "dev", "--workspace", "infra/workspace.yaml"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert "-f" not in args
+    assert "--python-file" not in args
+    resolve_defs_file_mock.assert_not_called()
+
+
+def test_run_cli_does_not_append_defs_file_with_short_workspace():
+    mock_cli = Mock()
+    with (
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch("cfa_dagster.utils.resolve_defs_file") as resolve_defs_file_mock,
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "code-server", "start", "-w", "workspace.yaml"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert "-f" not in args
+    assert "--python-file" not in args
+    resolve_defs_file_mock.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -500,7 +500,9 @@ def test_get_defs_target_default_definitions_flat_layout(tmp_path):
     assert defs_file == "my_project/definitions.py"
 
 
-def test_get_defs_target_default_definitions_raises_when_unresolvable(tmp_path):
+def test_get_defs_target_default_definitions_raises_when_unresolvable(
+    tmp_path,
+):
     project_dir = make_project_dir(tmp_path, DEFAULT_DEFS_TOML)
 
     with pytest.raises(RuntimeError, match="my_project.definitions"):
@@ -654,6 +656,96 @@ def test_run_cli_appends_resolved_defs_file_for_code_server():
 
     args = mock_cli.call_args.kwargs["args"]
     assert args[-2:] == ["-f", "/tmp/fake_defs.py"]
+
+
+def test_run_cli_replaces_default_defs_file_for_code_server_with_env():
+    mock_cli = Mock()
+    with (
+        patch.dict(
+            os.environ,
+            {"CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE": "true"},
+        ),
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch(
+            "cfa_dagster.utils.resolve_defs_file",
+            return_value="src/my_project/definitions.py",
+        ),
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "code-server", "start", "-f", "dagster_defs.py"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert "dagster_defs.py" not in args
+    assert args[args.index("-f") + 1] == "src/my_project/definitions.py"
+
+
+def test_run_cli_keeps_default_defs_file_without_override_env():
+    mock_cli = Mock()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch("cfa_dagster.utils.resolve_defs_file") as resolve_defs_file_mock,
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "code-server", "start", "-f", "dagster_defs.py"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert args[args.index("-f") + 1] == "dagster_defs.py"
+    resolve_defs_file_mock.assert_not_called()
+
+
+def test_run_cli_keeps_custom_defs_file_with_override_env():
+    mock_cli = Mock()
+    with (
+        patch.dict(
+            os.environ,
+            {"CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE": "true"},
+        ),
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch("cfa_dagster.utils.resolve_defs_file") as resolve_defs_file_mock,
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "code-server", "start", "-f", "custom_defs.py"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert args[args.index("-f") + 1] == "custom_defs.py"
+    resolve_defs_file_mock.assert_not_called()
+
+
+def test_run_cli_keeps_default_defs_file_when_override_resolution_fails():
+    mock_cli = Mock()
+    with (
+        patch.dict(
+            os.environ,
+            {"CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE": "true"},
+        ),
+        patch("cfa_dagster.utils.set_env_vars"),
+        patch("cfa_dagster.utils.configure_dev_db"),
+        patch(
+            "cfa_dagster.utils.resolve_defs_file",
+            side_effect=RuntimeError("bad pyproject"),
+        ),
+    ):
+        _run_cli(
+            mock_cli,
+            "TEST",
+            argv=["prog", "code-server", "start", "-f", "dagster_defs.py"],
+        )
+
+    args = mock_cli.call_args.kwargs["args"]
+    assert args[args.index("-f") + 1] == "dagster_defs.py"
 
 
 def test_run_cli_does_not_append_defs_file_with_workspace():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -431,7 +431,7 @@ def test_get_defs_target_flat_layout(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    assert defs_file == str(project_dir / "dagster_defs.py")
+    assert defs_file == "dagster_defs.py"
 
 
 def test_get_defs_target_package_layout_dotted_module(tmp_path):
@@ -443,8 +443,7 @@ def test_get_defs_target_package_layout_dotted_module(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    expected = project_dir / "cfa_epinow2_pipeline" / "dg_defs.py"
-    assert defs_file == str(expected)
+    assert defs_file == "cfa_epinow2_pipeline/dg_defs.py"
 
 
 def test_get_defs_target_src_layout_dotted_module(tmp_path):
@@ -456,8 +455,7 @@ def test_get_defs_target_src_layout_dotted_module(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    expected = project_dir / "src" / "cfa_epinow2_pipeline" / "dg_defs.py"
-    assert defs_file == str(expected)
+    assert defs_file == "src/cfa_epinow2_pipeline/dg_defs.py"
 
 
 def test_get_defs_target_prefers_flat_over_src_layout(tmp_path):
@@ -472,8 +470,7 @@ def test_get_defs_target_prefers_flat_over_src_layout(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    expected = project_dir / "cfa_epinow2_pipeline" / "dg_defs.py"
-    assert defs_file == str(expected)
+    assert defs_file == "cfa_epinow2_pipeline/dg_defs.py"
 
 
 def test_get_defs_target_raises_when_no_file_or_importable_module(tmp_path):
@@ -490,9 +487,7 @@ def test_get_defs_target_default_definitions_src_layout(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    assert defs_file == str(
-        project_dir / "src" / "my_project" / "definitions.py"
-    )
+    assert defs_file == "src/my_project/definitions.py"
 
 
 def test_get_defs_target_default_definitions_flat_layout(tmp_path):
@@ -502,7 +497,7 @@ def test_get_defs_target_default_definitions_flat_layout(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    assert defs_file == str(project_dir / "my_project" / "definitions.py")
+    assert defs_file == "my_project/definitions.py"
 
 
 def test_get_defs_target_default_definitions_raises_when_unresolvable(tmp_path):
@@ -525,8 +520,7 @@ def test_get_defs_target_explicit_defs_module_beats_default(tmp_path):
 
     defs_file = get_defs_target(project_dir)
 
-    expected = project_dir / "my_project" / "custom_defs.py"
-    assert defs_file == str(expected)
+    assert defs_file == "my_project/custom_defs.py"
 
 
 def test_get_defs_target_no_tool_dg_metadata(tmp_path):
@@ -567,9 +561,7 @@ def test_resolve_defs_file_returns_configured_file(tmp_path):
         tmp_path, FLAT_LAYOUT_TOML, ["dagster_defs.py"]
     )
 
-    assert resolve_defs_file(project_dir) == str(
-        project_dir / "dagster_defs.py"
-    )
+    assert resolve_defs_file(project_dir) == "dagster_defs.py"
 
 
 def test_resolve_defs_file_resolves_importable_module(tmp_path, monkeypatch):
@@ -583,7 +575,10 @@ def test_resolve_defs_file_resolves_importable_module(tmp_path, monkeypatch):
 
     project_dir = make_project_dir(tmp_path, toml)
 
-    assert resolve_defs_file(project_dir) == str(package_dir / "dg_defs.py")
+    assert (
+        resolve_defs_file(project_dir)
+        == "../modules/fake_pipeline_resolve/dg_defs.py"
+    )
 
 
 def test_get_defs_target_resolves_importable_module(tmp_path, monkeypatch):
@@ -597,7 +592,10 @@ def test_get_defs_target_resolves_importable_module(tmp_path, monkeypatch):
 
     project_dir = make_project_dir(tmp_path, toml)
 
-    assert get_defs_target(project_dir) == str(package_dir / "dg_defs.py")
+    assert (
+        get_defs_target(project_dir)
+        == "../modules/fake_pipeline_target/dg_defs.py"
+    )
 
 
 def test_resolve_defs_file_raises_when_unresolvable(tmp_path):


### PR DESCRIPTION
Closes #153

The main purpose of this PR is to remove the requirement for user code locations to have a `dagster_defs.py` file in the root of their repo. Instead, users can use the `[tool.dg]` metadata in their `pyproject.toml` to specify where their dagster definitions are location and what the python file is named.
An environment variable `CFA_DAGSTER_ALLOW_DEFAULT_DEFS_OVERRIDE` was introduced so we can still deploy user code locations that don't contain the latest fallback resolution code for `dagster code-server start`.