### PR TITLE
dga inheritance + metadata

### DIFF
--- a/src/cfa_dagster/__init__.py
+++ b/src/cfa_dagster/__init__.py
@@ -13,7 +13,7 @@ from .azure_container_app_job.launcher import AzureContainerAppJobRunLauncher
 from .azure_keyvault import AzureKeyVaultResource
 from .cli import start_dev_env
 from .docker.executor import docker_executor
-from .dynamic_graph_asset import (
+from .dynamic_graph import (
     GraphDimension,
     GraphDimensionExclusion,
     dynamic_graph_asset,

--- a/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/filesystem_io_manager.py
@@ -17,7 +17,7 @@ from dagster_azure.adls2 import ADLS2DefaultAzureCredential, ADLS2Resource
 from pydantic import Field
 from upath import UPath
 
-from ..dynamic_graph_asset_metadata import (
+from ..dynamic_graph.metadata import (
     DynamicGraphIOManagerMetadata,
     get_inherited_graph_dimension_input_metadata,
     patch_context_with_dynamic_graph_metadata,
@@ -130,10 +130,6 @@ class FilesystemADLS2IOManager(UPathIOManager):
             output_metadata
         )
 
-        if dynamic_graph_metadata and dynamic_graph_metadata.skip_output:
-            log.info("dump_to_path: skip_output=True, skipping upload")
-            return
-
         if dynamic_graph_metadata:
             patch_context_with_dynamic_graph_metadata(
                 context, dynamic_graph_metadata
@@ -156,10 +152,6 @@ class FilesystemADLS2IOManager(UPathIOManager):
         inherited_dimension_metadata = (
             get_inherited_graph_dimension_input_metadata(context)
         )
-
-        if dynamic_graph_metadata and dynamic_graph_metadata.skip_input:
-            log.debug("load_input: skip_input=True, returning None")
-            return
 
         # Inherited metadata is derived from the mapped input context and takes
         # precedence over static DynamicGraphIOManagerMetadata on the input.

--- a/src/cfa_dagster/azure_adls2/pickle_io_manager.py
+++ b/src/cfa_dagster/azure_adls2/pickle_io_manager.py
@@ -14,7 +14,7 @@ from dagster_azure.adls2 import (
 from dagster_azure.adls2.resources import ADLS2Resource
 from pydantic import Field
 
-from ..dynamic_graph_asset_metadata import (
+from ..dynamic_graph.metadata import (
     DynamicGraphIOManagerMetadata,
     get_inherited_graph_dimension_input_metadata,
     patch_context_with_dynamic_graph_metadata,
@@ -130,9 +130,6 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         dynamic_graph_metadata = DynamicGraphIOManagerMetadata.from_metadata(
             context.definition_metadata
         )
-        if dynamic_graph_metadata and dynamic_graph_metadata.skip_input:
-            context.log.debug("load_input: skip_input=True, returning None")
-            return
 
         # check if this was configured to inherit upstream graph dimensions
         inherited_dimension_metadata = (
@@ -156,12 +153,6 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
             context.output_metadata or {}
         )
         if dynamic_graph_metadata:
-            if dynamic_graph_metadata.skip_output:
-                context.log.debug(
-                    "handle_output: skip_output=True, skipping upload"
-                )
-                return
-
             patch_context_with_dynamic_graph_metadata(
                 context, dynamic_graph_metadata
             )

--- a/src/cfa_dagster/dynamic_graph/__init__.py
+++ b/src/cfa_dagster/dynamic_graph/__init__.py
@@ -1,0 +1,9 @@
+from .asset import GraphDimension, GraphDimensionExclusion, dynamic_graph_asset
+from .metadata import DynamicGraphIOManagerMetadata
+
+__all__ = [
+    "DynamicGraphIOManagerMetadata",
+    "GraphDimension",
+    "GraphDimensionExclusion",
+    "dynamic_graph_asset",
+]

--- a/src/cfa_dagster/dynamic_graph/asset.py
+++ b/src/cfa_dagster/dynamic_graph/asset.py
@@ -5,21 +5,17 @@ import logging
 import sys
 import textwrap
 import warnings
-from dataclasses import dataclass
 from types import GeneratorType
 from typing import (
     AbstractSet,
     Any,
     Callable,
-    Generic,
     Literal,
     Mapping,
     Optional,
     TypedDict,
-    TypeVar,
     Union,
     cast,
-    get_origin,
     get_type_hints,
 )
 from typing import Sequence as TypeSequence
@@ -31,17 +27,32 @@ from dagster._core.definitions.events import (
 )
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._utils.warnings import BetaWarning
-from pydantic import PrivateAttr
 from typing_extensions import Unpack
 
-from .azure_adls2.pickle_io_manager import ADLS2PickleIOManager
-from .dynamic_graph_asset_metadata import (
+from ..azure_adls2.pickle_io_manager import ADLS2PickleIOManager
+from ..execution.utils import ExecutionConfig, SelectorConfig
+from .config_inheritance import (
+    inherit_graph_dimension_axes_from_upstream_materializations,
+)
+from .metadata import (
     DYNAMIC_GRAPH_ASSET_METADATA_KEY,
     DynamicGraphIOManagerMetadata,
     _decode_mapping_key,
     _encode_mapping_key,
 )
-from .execution.utils import ExecutionConfig, SelectorConfig
+from .materialization_metadata import (
+    _get_graph_dimension_axes,
+    _get_graph_dimension_combinations,
+    _get_materialized_graph_dimensions_metadata,
+)
+from .types import (
+    GraphDimension,
+    GraphDimensionExclusion,
+    _DimensionResourceInfo,
+    _ExclusionResourceInfo,
+    _is_dimension_annotation,
+    _is_exclusion_annotation,
+)
 
 log = logging.getLogger(__name__)
 
@@ -67,45 +78,6 @@ class GraphAssetKwargs(TypedDict, total=False):
     code_version: Optional[str] = (None,)
     key: Optional[CoercibleToAssetKey] = (None,)
     kinds: Optional[AbstractSet[str]] = (None,)
-
-
-@dataclass
-class _DimensionResourceInfo:
-    param_name: str
-    resource_cls: type
-    dimension_fields: list[str]
-
-
-T = TypeVar("T", default=str)
-
-
-class GraphDimension(dg.Config, Generic[T]):
-    values: list[T]
-    _current_value: Optional[T] = PrivateAttr(default=None)
-
-    def __init__(self, values: list[str], current_value: Optional[str] = None):
-        super().__init__(values=values, _current_value=current_value)
-
-    def set_current_value(self, value: T) -> None:
-        self._current_value = value
-
-    @property
-    def current_value(self) -> Optional[T]:
-        return self._current_value
-
-
-class GraphDimensionExclusion(dg.Config, Generic[T]):
-    values: list[T] = []
-
-    def __init__(self, values: list[str]):
-        super().__init__(values=values)
-
-
-@dataclass
-class _ExclusionResourceInfo:
-    param_name: str
-    resource_cls: type
-    exclusion_fields: list[str]
 
 
 def _get_resource_params(hints) -> dict[str, type]:
@@ -236,35 +208,6 @@ def _get_asset_key(
         final_asset_key = dg.AssetKey(base_key)
     log.debug(f"final_asset_key: '{final_asset_key}'")
     return final_asset_key
-
-
-def _is_dimension_annotation(annotation) -> bool:
-    if get_origin(annotation) is GraphDimension:
-        return True
-
-    metadata = getattr(
-        annotation,
-        "__pydantic_generic_metadata__",
-        None,
-    )
-
-    return metadata is not None and metadata.get("origin") is GraphDimension
-
-
-def _is_exclusion_annotation(annotation) -> bool:
-    if get_origin(annotation) is GraphDimensionExclusion:
-        return True
-
-    metadata = getattr(
-        annotation,
-        "__pydantic_generic_metadata__",
-        None,
-    )
-
-    return (
-        metadata is not None
-        and metadata.get("origin") is GraphDimensionExclusion
-    )
 
 
 def _has_return_value(fn) -> bool:
@@ -585,6 +528,9 @@ def dynamic_graph_asset(
         log.debug(f"does_return_value: '{does_return_value}'")
 
         should_return_all = output_mode == "all"
+        should_load_compute_result = (
+            does_return_value and not should_return_all
+        )
 
         # -- Locate the Config parameter --
         config_cls = _get_config_cls(hints)
@@ -602,12 +548,6 @@ def dynamic_graph_asset(
         log.debug(f"decorated_fn_kwargs: {decorated_fn_kwargs}")
 
         final_asset_key = _get_asset_key(asset_name, graph_asset_kwargs)
-        graph_asset_metadata = {
-            **dict(graph_asset_kwargs.get("metadata") or {}),
-            DYNAMIC_GRAPH_ASSET_METADATA_KEY: {
-                "output_mode": output_mode,
-            },
-        }
 
         # -- Locate Resource parameters --
         resource_params = _get_resource_params(hints)
@@ -621,6 +561,12 @@ def dynamic_graph_asset(
         dimension_resource_info = _get_dimension_resource_info(
             asset_name, resource_params
         )
+        graph_asset_metadata = {
+            **dict(graph_asset_kwargs.get("metadata") or {}),
+            DYNAMIC_GRAPH_ASSET_METADATA_KEY: {
+                "output_mode": output_mode,
+            },
+        }
 
         # -- Locate resources containing GraphDimensionExclusion fields --
         exclusion_resources_info = _get_exclusion_resource_info(
@@ -655,6 +601,9 @@ def dynamic_graph_asset(
             out={
                 # Cheap fanout signal
                 "dga_internal_fanout": dg.DynamicOut(dg.Nothing),
+                "dga_internal_graph_dimensions": dg.Out(
+                    io_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
+                ),
                 **(
                     {
                         # Persisted ONCE and loaded by every mapped compute op
@@ -680,39 +629,25 @@ def dynamic_graph_asset(
                     output_name="dga_internal_shared_config",
                 )
 
-            dimension_resource = getattr(
-                context.resources,
-                dimension_resource_info.param_name,
+            axes = _get_graph_dimension_axes(
+                context,
+                dimension_resource_info,
+                exclusion_resources_info,
             )
-
-            axes = []
-
-            for dimension_field in dimension_resource_info.dimension_fields:
-                graph_dimension = getattr(
-                    dimension_resource,
-                    dimension_field,
-                )
-
-                values = graph_dimension.values
-
-                # filter out excluded dimension values across all exclusion resources
-                if exclusion_resources_info:
-                    excluded_values: set = set()
-                    for excl_info in exclusion_resources_info:
-                        excl_resource = getattr(
-                            context.resources, excl_info.param_name
-                        )
-                        exclusion_obj = getattr(
-                            excl_resource, dimension_field, None
-                        )
-                        if exclusion_obj is not None and exclusion_obj.values:
-                            excluded_values.update(set(exclusion_obj.values))
-                    if excluded_values:
-                        values = [
-                            v for v in values if v not in excluded_values
-                        ]
-
-                axes.append(values)
+            axes = inherit_graph_dimension_axes_from_upstream_materializations(
+                context,
+                axes,
+                dimension_resource_info,
+                op_ins,
+            )
+            graph_dimensions = _get_graph_dimension_combinations(
+                dimension_resource_info.dimension_fields,
+                axes,
+            )
+            yield dg.Output(
+                value=graph_dimensions,
+                output_name="dga_internal_graph_dimensions",
+            )
 
             for combo in itertools.product(*axes):
                 mapping_key = _encode_mapping_key(combo)
@@ -844,16 +779,12 @@ def dynamic_graph_asset(
                             if io_manager_key
                             else {}
                         ),
-                        metadata=(
-                            DynamicGraphIOManagerMetadata(
-                                skip_input=True
-                            ).to_dict()
-                            if should_return_all
-                            else {}
-                        ),
                     )
-                    if does_return_value
+                    if should_load_compute_result
                     else dg.In(dg.Nothing)
+                ),
+                "dga_internal_graph_dimensions": dg.In(
+                    input_manager_key=INTERNAL_CONFIG_IO_MANAGER_KEY,
                 ),
             },
             config_schema=config_cls.to_config_schema()
@@ -869,39 +800,63 @@ def dynamic_graph_asset(
                         ),
                     )
                 }
-                if does_return_value
+                if should_load_compute_result
                 else {"out": dg.Out(dg.Nothing)}
             ),
+            required_resource_keys=required_resource_keys,
             tags=_in_process_config.to_run_tags(),
         )
         def output_op(context, **kwargs):
             compute_result = kwargs.get("compute_result")
-            if does_return_value:
+            graph_dimensions = kwargs.get("dga_internal_graph_dimensions")
+            if should_load_compute_result:
                 result = compute_result
                 # handle yielded Output
                 if isinstance(result, GeneratorType):
                     result = next(result)
 
-                # handle sequences
-                result = result if should_return_all else result[0]
+                # output_mode="first" collects a single emitted compute value.
+                result = result[0]
 
                 result, metadata = _unpack_output(result)
 
                 # Merge our graph_dimensions metadata
                 merged_metadata = {
                     **dict(metadata),
-                    **(
-                        DynamicGraphIOManagerMetadata(
-                            skip_output=True
-                        ).to_dict()
-                        if should_return_all
-                        else {}
+                    **_get_materialized_graph_dimensions_metadata(
+                        context,
+                        dimension_resource_info,
+                        exclusion_resources_info,
+                        should_return_all,
+                        graph_dimensions,
                     ),
                 }
                 log.debug(f"merged_metadata: '{merged_metadata}'")
 
                 # Yield a new Output object with merged metadata
                 yield dg.Output(value=result, metadata=merged_metadata)
+            elif does_return_value:
+                yield dg.Output(
+                    value=None,
+                    metadata=_get_materialized_graph_dimensions_metadata(
+                        context,
+                        dimension_resource_info,
+                        exclusion_resources_info,
+                        should_return_all,
+                        graph_dimensions,
+                    ),
+                )
+            else:
+                yield dg.Output(
+                    value=None,
+                    metadata=_get_materialized_graph_dimensions_metadata(
+                        context,
+                        dimension_resource_info,
+                        exclusion_resources_info,
+                        should_return_all,
+                        graph_dimensions,
+                    ),
+                )
 
         # -- config mapping --
         if config_cls is not None:
@@ -950,11 +905,15 @@ def dynamic_graph_asset(
                 gen_result = gen_config(**ins_kwargs)
 
                 if config_cls is not None:
-                    dga_internal_fanout, dga_internal_shared_config = (
+                    (
+                        dga_internal_fanout,
+                        dga_internal_graph_dimensions,
+                        dga_internal_shared_config,
+                    ) = gen_result
+                else:
+                    dga_internal_fanout, dga_internal_graph_dimensions = (
                         gen_result
                     )
-                else:
-                    dga_internal_fanout = gen_result
                     dga_internal_shared_config = None
 
                 # Map fanout while passing shared config to every isolated compute worker
@@ -970,7 +929,10 @@ def dynamic_graph_asset(
                         **ins_kwargs,
                     )
                 )
-                return output_op(compute_result=res.collect())
+                return output_op(
+                    compute_result=res.collect(),
+                    dga_internal_graph_dimensions=dga_internal_graph_dimensions,
+                )
 
             return _asset
 

--- a/src/cfa_dagster/dynamic_graph/config_inheritance.py
+++ b/src/cfa_dagster/dynamic_graph/config_inheritance.py
@@ -1,0 +1,172 @@
+import logging
+from typing import Any
+
+import dagster as dg
+
+from .materialization_metadata import (
+    _GRAPH_DIMENSIONS_METADATA_KEY,
+)
+from .types import _DimensionResourceInfo
+
+log = logging.getLogger(__name__)
+
+
+def _metadata_value(raw):
+    if isinstance(raw, dg.MetadataValue):
+        return raw.value
+    return raw
+
+
+def _get_upstream_asset_key(input_name: str, op_in: dg.In) -> dg.AssetKey:
+    """Resolve the asset key represented by a dynamic graph input."""
+    if isinstance(op_in.asset_key, dg.AssetKey):
+        return op_in.asset_key
+    return dg.AssetKey(input_name)
+
+
+def _get_latest_materialization_metadata(
+    context: dg.OpExecutionContext,
+    asset_key: dg.AssetKey,
+) -> dict[str, Any]:
+    """Fetch latest upstream materialization metadata for this partition, if any."""
+    filter_kwargs = {"asset_key": asset_key}
+    if context.has_partition_key:
+        filter_kwargs["asset_partitions"] = [context.partition_key]
+
+    records_filter = dg.AssetRecordsFilter(**filter_kwargs)
+    result = context.instance.fetch_materializations(records_filter, limit=1)
+    if not result.records:
+        return {}
+
+    materialization = result.records[0].event_log_entry.asset_materialization
+    if materialization is None:
+        return {}
+    return materialization.metadata or {}
+
+
+def _get_graph_dimensions_metadata_parts(
+    metadata: dict[str, Any],
+) -> tuple[dict[str, Any] | None, list[Any] | None]:
+    """Read graph-dimension metadata from the consolidated materialization key."""
+    graph_dimensions_metadata = _metadata_value(
+        metadata.get(_GRAPH_DIMENSIONS_METADATA_KEY)
+    )
+    if isinstance(graph_dimensions_metadata, dict):
+        signature = graph_dimensions_metadata.get("signature")
+        materialized = graph_dimensions_metadata.get("materialized")
+        if isinstance(signature, dict) and isinstance(materialized, list):
+            return signature, materialized
+
+    return None, None
+
+
+def _get_inheritable_dimension_fields(
+    context: dg.OpExecutionContext,
+    dimension_resource_info: _DimensionResourceInfo,
+) -> set[str]:
+    """Return dimensions whose resource config allows upstream value inheritance."""
+    dimension_resource = getattr(
+        context.resources,
+        dimension_resource_info.param_name,
+    )
+    inheritable_fields = set()
+
+    for dimension_field in dimension_resource_info.dimension_fields:
+        graph_dimension = getattr(dimension_resource, dimension_field)
+        if getattr(graph_dimension, "inherit_values_from_upstream", True):
+            inheritable_fields.add(dimension_field)
+
+    return inheritable_fields
+
+
+def _narrow_axes_from_inherited_values(
+    axes: list[list[Any]],
+    dimension_fields: list[str],
+    inherited_values_by_field: dict[str, set[str]],
+) -> list[list[Any]]:
+    """Narrow axes to inherited values while preserving configured value order."""
+    narrowed_axes = []
+    for dimension_field, axis in zip(dimension_fields, axes):
+        inherited_values = inherited_values_by_field.get(dimension_field)
+        if not inherited_values:
+            narrowed_axes.append(axis)
+            continue
+
+        narrowed_axis = [
+            value for value in axis if str(value) in inherited_values
+        ]
+        if narrowed_axis:
+            narrowed_axes.append(narrowed_axis)
+            continue
+
+        log.warning(
+            "Inherited graph dimension values for '%s' did not match any "
+            "configured values; using configured values instead.",
+            dimension_field,
+        )
+        narrowed_axes.append(axis)
+
+    return narrowed_axes
+
+
+def inherit_graph_dimension_axes_from_upstream_materializations(
+    context: dg.OpExecutionContext,
+    axes: list[list[Any]],
+    dimension_resource_info: _DimensionResourceInfo,
+    op_ins: dict[str, dg.In],
+) -> list[list[Any]]:
+    """Capture graph dimensions using matching upstream dynamic graph materializations."""
+    inheritable_fields = _get_inheritable_dimension_fields(
+        context,
+        dimension_resource_info,
+    )
+    if not inheritable_fields:
+        return axes
+
+    inherited_values_by_field: dict[str, set[str]] = {}
+
+    for input_name, op_in in op_ins.items():
+        metadata = _get_latest_materialization_metadata(
+            context,
+            _get_upstream_asset_key(input_name, op_in),
+        )
+        signature, graph_dimensions = _get_graph_dimensions_metadata_parts(
+            metadata
+        )
+
+        if not isinstance(signature, dict) or not isinstance(
+            graph_dimensions, list
+        ):
+            continue
+        if (
+            signature.get("dimension_resource_key")
+            != dimension_resource_info.param_name
+        ):
+            continue
+
+        upstream_fields = set(signature.get("dimension_fields") or [])
+        matching_fields = (
+            upstream_fields
+            & set(dimension_resource_info.dimension_fields)
+            & inheritable_fields
+        )
+        if not matching_fields:
+            continue
+
+        for graph_dimension in graph_dimensions:
+            if not isinstance(graph_dimension, dict):
+                continue
+            for field in matching_fields:
+                if field in graph_dimension:
+                    inherited_values_by_field.setdefault(field, set()).add(
+                        str(graph_dimension[field])
+                    )
+
+    if not inherited_values_by_field:
+        return axes
+
+    return _narrow_axes_from_inherited_values(
+        axes,
+        dimension_resource_info.dimension_fields,
+        inherited_values_by_field,
+    )

--- a/src/cfa_dagster/dynamic_graph/materialization_metadata.py
+++ b/src/cfa_dagster/dynamic_graph/materialization_metadata.py
@@ -1,0 +1,306 @@
+import itertools
+import math
+from typing import Any, get_type_hints
+
+import dagster as dg
+
+from .types import (
+    _DimensionResourceInfo,
+    _ExclusionResourceInfo,
+    _get_graph_dimension_value_type,
+    _get_string_enum_values,
+)
+
+_GRAPH_DIMENSIONS_METADATA_KEY = "cfa_dagster/graph_dimensions"
+_GRAPH_DIMENSIONS_MD_METADATA_KEY = "cfa_dagster/graph_dimensions_md"
+
+
+def _graph_dimensions_markdown_table(
+    dimension_fields: list[str],
+    graph_dimensions: list[dict[str, str]],
+    enum_dimension_coverage: list[dict[str, Any]] | None = None,
+    cartesian_enum_domain_coverage: dict[str, Any] | None = None,
+) -> str:
+    """Render materialized graph dimensions and enum coverage for Dagster UI metadata."""
+    if not graph_dimensions:
+        markdown = "No graph dimensions materialized."
+    else:
+        header = "| " + " | ".join(dimension_fields) + " |"
+        separator = "| " + " | ".join(["---"] * len(dimension_fields)) + " |"
+        rows = [
+            "| "
+            + " | ".join(
+                str(graph_dimension[field]) for field in dimension_fields
+            )
+            + " |"
+            for graph_dimension in graph_dimensions
+        ]
+        markdown = "\n".join(
+            ["### Materialized Graph Dimensions", "", header, separator, *rows]
+        )
+
+    if enum_dimension_coverage:
+        coverage_rows = [
+            "| {dimension} | {materialized_value_count} | {enum_domain_count} | {coverage_percent:.2f}% |".format(
+                **coverage
+            )
+            for coverage in enum_dimension_coverage
+        ]
+        markdown = "\n".join(
+            [
+                markdown,
+                "",
+                "### Enum Dimension Coverage",
+                "",
+                "| Dimension | Materialized values | Enum domain | Coverage |",
+                "| --- | ---: | ---: | ---: |",
+                *coverage_rows,
+            ]
+        )
+
+    if cartesian_enum_domain_coverage:
+        markdown = "\n".join(
+            [
+                markdown,
+                "",
+                "### Graph Dimension Domain Coverage",
+                "",
+                "| Materialized combinations | Total enum domain | Coverage |",
+                "| ---: | ---: | ---: |",
+                "| {materialized_count} | {total_domain_count} | {coverage_percent:.2f}% |".format(
+                    **cartesian_enum_domain_coverage
+                ),
+            ]
+        )
+
+    return markdown
+
+
+def _get_graph_dimension_axes(
+    context,
+    dimension_resource_info: _DimensionResourceInfo,
+    exclusion_resources_info: list[_ExclusionResourceInfo],
+) -> list[list[Any]]:
+    """Return dimension value axes after applying any configured exclusions."""
+    dimension_resource = getattr(
+        context.resources,
+        dimension_resource_info.param_name,
+    )
+
+    axes = []
+
+    for dimension_field in dimension_resource_info.dimension_fields:
+        graph_dimension = getattr(
+            dimension_resource,
+            dimension_field,
+        )
+
+        values = graph_dimension.values
+
+        if exclusion_resources_info:
+            excluded_values: set = set()
+            for excl_info in exclusion_resources_info:
+                excl_resource = getattr(
+                    context.resources, excl_info.param_name
+                )
+                exclusion_obj = getattr(
+                    excl_resource,
+                    dimension_field,
+                    None,
+                )
+                if exclusion_obj is not None and exclusion_obj.values:
+                    excluded_values.update(set(exclusion_obj.values))
+            if excluded_values:
+                values = [v for v in values if v not in excluded_values]
+
+        axes.append(values)
+
+    return axes
+
+
+def _get_graph_dimension_combinations(
+    dimension_fields: list[str],
+    axes: list[list[Any]],
+) -> list[dict[str, str]]:
+    """Convert the cartesian product of dimension axes into metadata rows."""
+    return [
+        {field: str(value) for field, value in zip(dimension_fields, combo)}
+        for combo in itertools.product(*axes)
+    ]
+
+
+def _get_materialized_graph_dimensions(
+    context,
+    dimension_resource_info: _DimensionResourceInfo,
+    exclusion_resources_info: list[_ExclusionResourceInfo],
+    should_return_all: bool,
+) -> list[dict[str, str]]:
+    """Return the graph dimension combinations represented by the asset output."""
+    graph_dimensions = _get_graph_dimension_combinations(
+        dimension_resource_info.dimension_fields,
+        _get_graph_dimension_axes(
+            context,
+            dimension_resource_info,
+            exclusion_resources_info,
+        ),
+    )
+
+    return graph_dimensions if should_return_all else graph_dimensions[:1]
+
+
+def _get_enum_dimension_coverage(
+    graph_dimensions: list[dict[str, str]],
+    dimension_resource_info: _DimensionResourceInfo,
+) -> list[dict[str, Any]]:
+    """Summarize materialized coverage for dimensions backed by string enums."""
+    resource_hints = get_type_hints(dimension_resource_info.resource_cls)
+    enum_dimension_coverage = []
+
+    for dimension_field in dimension_resource_info.dimension_fields:
+        value_type = _get_graph_dimension_value_type(
+            resource_hints.get(dimension_field)
+        )
+        enum_values = _get_string_enum_values(value_type)
+        if enum_values is None:
+            continue
+
+        materialized_values = {
+            graph_dimension[dimension_field]
+            for graph_dimension in graph_dimensions
+        }
+        enum_domain_count = len(enum_values)
+        materialized_value_count = len(materialized_values)
+        enum_dimension_coverage.append(
+            {
+                "dimension": dimension_field,
+                "materialized_value_count": materialized_value_count,
+                "enum_domain_count": enum_domain_count,
+                "coverage_percent": (
+                    materialized_value_count / enum_domain_count * 100
+                )
+                if enum_domain_count
+                else 0,
+            }
+        )
+
+    return enum_dimension_coverage
+
+
+def _get_graph_dimension_enum_domains(
+    dimension_resource_info: _DimensionResourceInfo,
+) -> dict[str, list[str]] | None:
+    """Return enum domains only when every graph dimension has a string enum type."""
+    enum_domains = _get_graph_dimension_enum_domain_map(
+        dimension_resource_info
+    )
+    if len(enum_domains) != len(dimension_resource_info.dimension_fields):
+        return None
+    return enum_domains
+
+
+def _get_graph_dimension_enum_domain_map(
+    dimension_resource_info: _DimensionResourceInfo,
+) -> dict[str, list[str]]:
+    """Return enum domains for graph dimensions that declare a string enum type."""
+    resource_hints = get_type_hints(dimension_resource_info.resource_cls)
+    enum_domains = {}
+
+    for dimension_field in dimension_resource_info.dimension_fields:
+        value_type = _get_graph_dimension_value_type(
+            resource_hints.get(dimension_field)
+        )
+        enum_values = _get_string_enum_values(value_type)
+        if enum_values is None:
+            continue
+        enum_domains[dimension_field] = enum_values
+
+    return enum_domains
+
+
+def _get_graph_dimension_signature(
+    dimension_resource_info: _DimensionResourceInfo,
+) -> dict[str, Any]:
+    """Describe the graph-dimension resource contract without Python class identity."""
+    return {
+        "dimension_resource_key": dimension_resource_info.param_name,
+        "dimension_fields": dimension_resource_info.dimension_fields,
+        "enum_domains": _get_graph_dimension_enum_domain_map(
+            dimension_resource_info
+        ),
+    }
+
+
+def _get_cartesian_enum_domain_coverage(
+    graph_dimensions: list[dict[str, str]],
+    dimension_resource_info: _DimensionResourceInfo,
+) -> dict[str, Any] | None:
+    """Calculate materialized combinations over the full enum cartesian domain."""
+    enum_domains = _get_graph_dimension_enum_domains(dimension_resource_info)
+    if enum_domains is None:
+        return None
+
+    dimension_fields = dimension_resource_info.dimension_fields
+    materialized_count = len(
+        {
+            tuple(graph_dimension[field] for field in dimension_fields)
+            for graph_dimension in graph_dimensions
+        }
+    )
+    total_domain_count = math.prod(
+        len(enum_domains[field]) for field in dimension_fields
+    )
+
+    return {
+        "materialized_count": materialized_count,
+        "total_domain_count": total_domain_count,
+        "coverage_percent": materialized_count / total_domain_count * 100
+        if total_domain_count
+        else 0,
+    }
+
+
+def _get_materialized_graph_dimensions_metadata(
+    context,
+    dimension_resource_info: _DimensionResourceInfo,
+    exclusion_resources_info: list[_ExclusionResourceInfo],
+    should_return_all: bool,
+    graph_dimensions: list[dict[str, str]] | None = None,
+) -> dict:
+    """Build Dagster materialization metadata for dynamic graph dimensions."""
+    if graph_dimensions is None:
+        graph_dimensions = _get_materialized_graph_dimensions(
+            context,
+            dimension_resource_info,
+            exclusion_resources_info,
+            should_return_all,
+        )
+    enum_dimension_coverage = _get_enum_dimension_coverage(
+        graph_dimensions,
+        dimension_resource_info,
+    )
+    cartesian_enum_domain_coverage = _get_cartesian_enum_domain_coverage(
+        graph_dimensions,
+        dimension_resource_info,
+    )
+
+    signature = _get_graph_dimension_signature(dimension_resource_info)
+    return {
+        _GRAPH_DIMENSIONS_METADATA_KEY: dg.MetadataValue.json(
+            {
+                "materialized": graph_dimensions,
+                "signature": signature,
+                "coverage": {
+                    "enum_dimensions": enum_dimension_coverage,
+                    "cartesian_enum_domain": cartesian_enum_domain_coverage,
+                },
+            }
+        ),
+        _GRAPH_DIMENSIONS_MD_METADATA_KEY: dg.MetadataValue.md(
+            _graph_dimensions_markdown_table(
+                dimension_resource_info.dimension_fields,
+                graph_dimensions,
+                enum_dimension_coverage,
+                cartesian_enum_domain_coverage,
+            )
+        ),
+    }

--- a/src/cfa_dagster/dynamic_graph/metadata.py
+++ b/src/cfa_dagster/dynamic_graph/metadata.py
@@ -27,8 +27,6 @@ class DynamicGraphIOManagerMetadata:
     asset_key_path: list[str] = field(default_factory=list)
     asset_partition_keys: list[Any] = field(default_factory=list)
     synthetic_partition_keys: list[str] = field(default_factory=list)
-    skip_input: bool = False
-    skip_output: bool = False
 
     @classmethod
     def from_metadata(
@@ -49,8 +47,6 @@ class DynamicGraphIOManagerMetadata:
             asset_key_path=raw.get("asset_key_path", []),
             asset_partition_keys=raw.get("asset_partition_keys", []),
             synthetic_partition_keys=raw.get("synthetic_partition_keys", []),
-            skip_input=raw.get("skip_input", False),
-            skip_output=raw.get("skip_output", False),
         )
 
     def to_dict(self) -> dict:

--- a/src/cfa_dagster/dynamic_graph/types.py
+++ b/src/cfa_dagster/dynamic_graph/types.py
@@ -1,0 +1,108 @@
+import inspect
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, Optional, TypeVar, get_origin
+
+import dagster as dg
+from pydantic import PrivateAttr
+
+
+@dataclass
+class _DimensionResourceInfo:
+    param_name: str
+    resource_cls: type
+    dimension_fields: list[str]
+
+
+T = TypeVar("T", default=str)
+
+
+class GraphDimension(dg.Config, Generic[T]):
+    values: list[T]
+    inherit_values_from_upstream: bool = True
+    _current_value: Optional[T] = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        values: list[T],
+        current_value: Optional[T] = None,
+        inherit_values_from_upstream: bool = True,
+    ):
+        super().__init__(
+            values=values,
+            inherit_values_from_upstream=inherit_values_from_upstream,
+            _current_value=current_value,
+        )
+
+    def set_current_value(self, value: T) -> None:
+        self._current_value = value
+
+    @property
+    def current_value(self) -> Optional[T]:
+        return self._current_value
+
+
+class GraphDimensionExclusion(dg.Config, Generic[T]):
+    values: list[T] = []
+
+    def __init__(self, values: list[str]):
+        super().__init__(values=values)
+
+
+@dataclass
+class _ExclusionResourceInfo:
+    param_name: str
+    resource_cls: type
+    exclusion_fields: list[str]
+
+
+def _is_dimension_annotation(annotation) -> bool:
+    if get_origin(annotation) is GraphDimension:
+        return True
+
+    metadata = getattr(
+        annotation,
+        "__pydantic_generic_metadata__",
+        None,
+    )
+
+    return metadata is not None and metadata.get("origin") is GraphDimension
+
+
+def _is_exclusion_annotation(annotation) -> bool:
+    if get_origin(annotation) is GraphDimensionExclusion:
+        return True
+
+    metadata = getattr(
+        annotation,
+        "__pydantic_generic_metadata__",
+        None,
+    )
+
+    return (
+        metadata is not None
+        and metadata.get("origin") is GraphDimensionExclusion
+    )
+
+
+def _get_graph_dimension_value_type(annotation) -> Optional[type]:
+    metadata = getattr(
+        annotation,
+        "__pydantic_generic_metadata__",
+        None,
+    )
+    if metadata is None or metadata.get("origin") is not GraphDimension:
+        return None
+
+    args = metadata.get("args") or ()
+    return args[0] if args else None
+
+
+def _get_string_enum_values(value_type) -> Optional[list[str]]:
+    if (
+        inspect.isclass(value_type)
+        and issubclass(value_type, Enum)
+        and issubclass(value_type, str)
+    ):
+        return [str(member.value) for member in value_type]
+    return None

--- a/tests/test_dynamic_graph_asset_integration.py
+++ b/tests/test_dynamic_graph_asset_integration.py
@@ -1,17 +1,35 @@
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import dagster as dg
+import pytest
 
-from cfa_dagster.dynamic_graph_asset import GraphDimension, dynamic_graph_asset
-from cfa_dagster.dynamic_graph_asset_metadata import (
+from cfa_dagster.azure_adls2.pickle_io_manager import ADLS2PickleIOManager
+from cfa_dagster.dynamic_graph import GraphDimension, dynamic_graph_asset
+from cfa_dagster.dynamic_graph.metadata import (
     DYNAMIC_GRAPH_ASSET_METADATA_KEY,
+    DYNAMIC_GRAPH_IO_MANAGER_METADATA_KEY,
     DynamicGraphIOManagerMetadata,
+)
+
+_GRAPH_DIMENSION_FIELDS_METADATA_KEY = "cfa_dagster/graph_dimension_fields"
+_GRAPH_DIMENSIONS_METADATA_KEY = "cfa_dagster/graph_dimensions"
+_GRAPH_DIMENSIONS_MATERIALIZED_METADATA_KEY = (
+    "cfa_dagster/graph_dimensions_materialized"
+)
+_GRAPH_DIMENSIONS_MD_METADATA_KEY = "cfa_dagster/graph_dimensions_md"
+_GRAPH_DIMENSIONS_MATERIALIZED_MD_METADATA_KEY = (
+    "cfa_dagster/graph_dimensions_materialized_md"
+)
+_GRAPH_DIMENSION_SIGNATURE_METADATA_KEY = (
+    "cfa_dagster/graph_dimension_signature"
 )
 
 _NO_RETURN_VALUES: list[str] = []
 _FILE_OUTPUT_DIR: Path | None = None
 _FIRST_MODE_CONSUMED: list[dict[str, str]] = []
+_INHERITED_VALUES: list[dict[str, str]] = []
 
 
 class NoReturnDims(dg.ConfigurableResource):
@@ -30,11 +48,73 @@ class FirstModeDims(dg.ConfigurableResource):
     letter: GraphDimension[str] = GraphDimension(["a", "b"])
 
 
+class AlphaEnum(StrEnum):
+    a = "a"
+    b = "b"
+    c = "c"
+
+
+class NumberEnum(StrEnum):
+    one = "one"
+    two = "two"
+
+
+class ReverseAlphaEnum(StrEnum):
+    z = "z"
+    y = "y"
+    x = "x"
+
+
+class EnumAllModeDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b"])
+
+
+class EnumFirstModeDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b"])
+
+
+class MultiEnumDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b"])
+    number: GraphDimension[NumberEnum] = GraphDimension(["one", "two"])
+
+
+class FirstModeMultiEnumDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b", "c"])
+    reverse_letter: GraphDimension[ReverseAlphaEnum] = GraphDimension(
+        ["x", "y"]
+    )
+
+
+class InheritanceDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b", "c"])
+
+
+class OtherInheritanceDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b", "c"])
+
+
+class OtherFieldInheritanceDims(dg.ConfigurableResource):
+    number: GraphDimension[NumberEnum] = GraphDimension(["one", "two"])
+
+
+class InheritanceOptOutDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(
+        ["a", "b", "c"],
+        inherit_values_from_upstream=False,
+    )
+
+
+class MixedInheritanceDims(dg.ConfigurableResource):
+    letter: GraphDimension[AlphaEnum] = GraphDimension(["a", "b", "c"])
+    number: GraphDimension[NumberEnum] = GraphDimension(
+        ["one", "two"],
+        inherit_values_from_upstream=False,
+    )
+
+
 class RecordingIOManager(dg.IOManager):
     def __init__(self):
         self.outputs: list[dict[str, Any]] = []
-        self.skipped_inputs: list[str] = []
-        self.skipped_outputs: list[dict[str, Any]] = []
         self._step_outputs: dict[tuple[str, str], Any] = {}
         self._asset_outputs: dict[tuple[str, ...], Any] = {}
 
@@ -42,16 +122,6 @@ class RecordingIOManager(dg.IOManager):
         meta = DynamicGraphIOManagerMetadata.from_metadata(
             context.output_metadata or {}
         )
-        if meta and meta.skip_output:
-            self.skipped_outputs.append(
-                {
-                    "step_key": context.step_key,
-                    "obj": obj,
-                    "metadata": meta,
-                }
-            )
-            return
-
         self.outputs.append(
             {
                 "step_key": context.step_key,
@@ -64,13 +134,6 @@ class RecordingIOManager(dg.IOManager):
             self._asset_outputs[tuple(context.asset_key.path)] = obj
 
     def load_input(self, context: dg.InputContext) -> Any:
-        meta = DynamicGraphIOManagerMetadata.from_metadata(
-            context.definition_metadata
-        )
-        if meta and meta.skip_input:
-            self.skipped_inputs.append(context.name)
-            return None
-
         if context.upstream_output:
             step_key = context.upstream_output.step_key
             output_name = context.upstream_output.name
@@ -85,6 +148,56 @@ class RecordingIOManager(dg.IOManager):
         raise AssertionError(
             f"Unexpected input load for {context.name}: {context.definition_metadata}"
         )
+
+
+@pytest.fixture(autouse=True)
+def _use_in_memory_internal_config_io_manager(monkeypatch):
+    class FakeInternalConfigIOManager:
+        def __init__(self):
+            self._step_outputs: dict[tuple[str, str], Any] = {}
+
+        def handle_output(self, context: dg.OutputContext, obj: Any) -> None:
+            self._step_outputs[(context.step_key, context.name)] = obj
+
+        def load_input(self, context: dg.InputContext) -> Any:
+            if context.upstream_output:
+                key = (
+                    context.upstream_output.step_key,
+                    context.upstream_output.name,
+                )
+                if key in self._step_outputs:
+                    return self._step_outputs[key]
+
+            raise AssertionError(
+                f"Unexpected internal input load: {context.name}"
+            )
+
+    manager = FakeInternalConfigIOManager()
+    monkeypatch.setattr(
+        ADLS2PickleIOManager,
+        "_internal_io_manager",
+        property(lambda self: manager),
+    )
+
+
+def _asset_materialization_metadata(result, asset_key: dg.AssetKey):
+    for event in result.get_asset_materialization_events():
+        materialization = event.event_specific_data.materialization
+        if materialization.asset_key == asset_key:
+            return materialization.metadata
+    raise AssertionError(f"No materialization found for {asset_key}")
+
+
+def _graph_dimensions_metadata(metadata):
+    return metadata[_GRAPH_DIMENSIONS_METADATA_KEY].value
+
+
+def _assert_legacy_graph_dimension_keys_absent(metadata):
+    assert _GRAPH_DIMENSION_FIELDS_METADATA_KEY not in metadata
+    assert _GRAPH_DIMENSIONS_MATERIALIZED_METADATA_KEY not in metadata
+    assert _GRAPH_DIMENSION_SIGNATURE_METADATA_KEY not in metadata
+    assert _GRAPH_DIMENSIONS_MATERIALIZED_MD_METADATA_KEY not in metadata
+    assert DYNAMIC_GRAPH_IO_MANAGER_METADATA_KEY not in metadata
 
 
 @dynamic_graph_asset
@@ -122,6 +235,188 @@ def dynamic_asset_returns_first_object(
     return {"letter": first_mode_dims.letter.current_value}
 
 
+@dynamic_graph_asset(io_manager_key="recording_io", output_mode="all")
+def dynamic_asset_returns_enum_objects_all(
+    context: dg.OpExecutionContext,
+    enum_all_mode_dims: EnumAllModeDims,
+) -> dict[str, str]:
+    return {"letter": enum_all_mode_dims.letter.current_value}
+
+
+@dynamic_graph_asset(io_manager_key="recording_io", output_mode="first")
+def dynamic_asset_returns_enum_objects_first(
+    context: dg.OpExecutionContext,
+    enum_first_mode_dims: EnumFirstModeDims,
+) -> dict[str, str]:
+    return {"letter": enum_first_mode_dims.letter.current_value}
+
+
+@dynamic_graph_asset(io_manager_key="recording_io", output_mode="all")
+def dynamic_asset_returns_multi_enum_objects(
+    context: dg.OpExecutionContext,
+    multi_enum_dims: MultiEnumDims,
+) -> dict[str, str]:
+    return {
+        "letter": multi_enum_dims.letter.current_value,
+        "number": multi_enum_dims.number.current_value,
+    }
+
+
+@dynamic_graph_asset(io_manager_key="recording_io", output_mode="first")
+def dynamic_asset_returns_multi_enum_objects_first(
+    context: dg.OpExecutionContext,
+    first_mode_multi_enum_dims: FirstModeMultiEnumDims,
+) -> dict[str, str]:
+    return {
+        "letter": first_mode_multi_enum_dims.letter.current_value,
+        "reverse_letter": first_mode_multi_enum_dims.reverse_letter.current_value,
+    }
+
+
+@dynamic_graph_asset
+def inheritance_upstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset
+def inheritance_upstream_b(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset
+def same_resource_key_different_field_upstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: OtherFieldInheritanceDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset(
+    ins={"inheritance_upstream": dg.In(dg.Nothing)},
+)
+def inheritance_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset(
+    ins={
+        "inheritance_upstream": dg.In(dg.Nothing),
+        "inheritance_upstream_b": dg.In(dg.Nothing),
+    },
+)
+def inheritance_multi_upstream_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset(
+    ins={
+        "inheritance_upstream": dg.In(dg.Nothing),
+        "other_resource_key_upstream": dg.In(dg.Nothing),
+    },
+)
+def matching_and_different_resource_key_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset(
+    ins={
+        "inheritance_upstream": dg.In(dg.Nothing),
+        "same_resource_key_different_field_upstream": dg.In(dg.Nothing),
+    },
+)
+def matching_and_different_field_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset
+def other_resource_key_upstream(
+    context: dg.OpExecutionContext,
+    other_inheritance_dims: OtherInheritanceDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset(
+    ins={"other_resource_key_upstream": dg.In(dg.Nothing)},
+)
+def different_resource_key_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_dims: InheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset
+def inheritance_opt_out_upstream(
+    context: dg.OpExecutionContext,
+    inheritance_opt_out_dims: InheritanceOptOutDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset(
+    ins={"inheritance_opt_out_upstream": dg.In(dg.Nothing)},
+)
+def inheritance_opt_out_downstream(
+    context: dg.OpExecutionContext,
+    inheritance_opt_out_dims: InheritanceOptOutDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {"letter": str(inheritance_opt_out_dims.letter.current_value)}
+    )
+
+
+@dynamic_graph_asset
+def mixed_inheritance_upstream(
+    context: dg.OpExecutionContext,
+    mixed_inheritance_dims: MixedInheritanceDims,
+) -> None:
+    pass
+
+
+@dynamic_graph_asset(
+    ins={"mixed_inheritance_upstream": dg.In(dg.Nothing)},
+)
+def mixed_inheritance_downstream(
+    context: dg.OpExecutionContext,
+    mixed_inheritance_dims: MixedInheritanceDims,
+) -> None:
+    _INHERITED_VALUES.append(
+        {
+            "letter": str(mixed_inheritance_dims.letter.current_value),
+            "number": str(mixed_inheritance_dims.number.current_value),
+        }
+    )
+
+
 @dg.asset
 def normal_asset_consumes_first_object(
     dynamic_asset_returns_first_object: dict[str, str],
@@ -140,6 +435,18 @@ def test_dynamic_graph_asset_without_return_runs_all_dimensions():
 
     assert result.success
     assert sorted(_NO_RETURN_VALUES) == ["a", "b"]
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_no_return.key,
+    )
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["signature"]["dimension_fields"] == ["letter"]
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    assert _GRAPH_DIMENSIONS_MD_METADATA_KEY in metadata
+    _assert_legacy_graph_dimension_keys_absent(metadata)
 
 
 def test_dynamic_graph_asset_metadata_records_output_mode():
@@ -151,7 +458,32 @@ def test_dynamic_graph_asset_metadata_records_output_mode():
     ][DYNAMIC_GRAPH_ASSET_METADATA_KEY] == {"output_mode": "all"}
 
 
-def test_dynamic_graph_asset_returning_objects_skips_output_transport_loads():
+def test_dynamic_graph_asset_materialization_records_dimension_signature():
+    result = dg.materialize(
+        [dynamic_asset_returns_enum_objects_all],
+        resources={
+            "enum_all_mode_dims": EnumAllModeDims(),
+            "recording_io": dg.IOManagerDefinition.hardcoded_io_manager(
+                RecordingIOManager()
+            ),
+        },
+    )
+
+    assert result.success
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_enum_objects_all.key,
+    )
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["signature"] == {
+        "dimension_resource_key": "enum_all_mode_dims",
+        "dimension_fields": ["letter"],
+        "enum_domains": {"letter": ["a", "b", "c"]},
+    }
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_returning_objects_does_not_load_collected_outputs_in_all_mode():
     recording_io = RecordingIOManager()
 
     result = dg.materialize(
@@ -173,11 +505,30 @@ def test_dynamic_graph_asset_returning_objects_skips_output_transport_loads():
         output["metadata"].synthetic_partition_keys
         for output in recording_io.outputs
     ] == [["a"], ["b"]]
-    assert recording_io.skipped_inputs == ["compute_result", "compute_result"]
-    assert len(recording_io.skipped_outputs) == 1
+
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_objects.key,
+    )
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["signature"]["dimension_fields"] == ["letter"]
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    assert (
+        "Enum Dimension Coverage"
+        not in metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    )
+    assert (
+        "Graph Dimension Domain Coverage"
+        not in metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    )
+    assert "| a |" in metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    _assert_legacy_graph_dimension_keys_absent(metadata)
 
 
-def test_dynamic_graph_asset_returning_files_skips_output_transport_loads(
+def test_dynamic_graph_asset_returning_files_does_not_load_collected_outputs_in_all_mode(
     tmp_path,
 ):
     global _FILE_OUTPUT_DIR
@@ -203,8 +554,6 @@ def test_dynamic_graph_asset_returning_files_skips_output_transport_loads(
         output["metadata"].synthetic_partition_keys
         for output in recording_io.outputs
     ] == [["a"], ["b"]]
-    assert recording_io.skipped_inputs == ["compute_result", "compute_result"]
-    assert len(recording_io.skipped_outputs) == 1
 
 
 def test_dynamic_graph_asset_output_mode_first_can_feed_normal_asset():
@@ -226,5 +575,464 @@ def test_dynamic_graph_asset_output_mode_first_can_feed_normal_asset():
 
     assert result.success
     assert _FIRST_MODE_CONSUMED == [{"letter": "a"}]
-    assert recording_io.skipped_inputs == []
-    assert recording_io.skipped_outputs == []
+
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_first_object.key,
+    )
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["signature"]["dimension_fields"] == ["letter"]
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_inherits_upstream_dimension_values_by_default():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    upstream_result = dg.materialize(
+        [inheritance_upstream],
+        resources={
+            "inheritance_dims": InheritanceDims(letter=GraphDimension(["a"])),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(inheritance_upstream.key),
+            inheritance_downstream,
+        ],
+        resources={"inheritance_dims": InheritanceDims()},
+        instance=instance,
+    )
+
+    assert upstream_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [{"letter": "a"}]
+    metadata = _asset_materialization_metadata(
+        downstream_result,
+        inheritance_downstream.key,
+    )
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_unions_values_from_multiple_matching_upstreams():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    upstream_a_result = dg.materialize(
+        [inheritance_upstream],
+        resources={
+            "inheritance_dims": InheritanceDims(letter=GraphDimension(["a"])),
+        },
+        instance=instance,
+    )
+    upstream_b_result = dg.materialize(
+        [inheritance_upstream_b],
+        resources={
+            "inheritance_dims": InheritanceDims(letter=GraphDimension(["b"])),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(inheritance_upstream.key),
+            dg.AssetSpec(inheritance_upstream_b.key),
+            inheritance_multi_upstream_downstream,
+        ],
+        resources={"inheritance_dims": InheritanceDims()},
+        instance=instance,
+    )
+
+    assert upstream_a_result.success
+    assert upstream_b_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [{"letter": "a"}, {"letter": "b"}]
+    metadata = _asset_materialization_metadata(
+        downstream_result,
+        inheritance_multi_upstream_downstream.key,
+    )
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_ignores_non_matching_resource_key_with_matching_upstream():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    matching_result = dg.materialize(
+        [inheritance_upstream],
+        resources={
+            "inheritance_dims": InheritanceDims(letter=GraphDimension(["a"])),
+        },
+        instance=instance,
+    )
+    non_matching_result = dg.materialize(
+        [other_resource_key_upstream],
+        resources={
+            "other_inheritance_dims": OtherInheritanceDims(
+                letter=GraphDimension(["b"])
+            ),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(inheritance_upstream.key),
+            dg.AssetSpec(other_resource_key_upstream.key),
+            matching_and_different_resource_key_downstream,
+        ],
+        resources={"inheritance_dims": InheritanceDims()},
+        instance=instance,
+    )
+
+    assert matching_result.success
+    assert non_matching_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [{"letter": "a"}]
+    metadata = _asset_materialization_metadata(
+        downstream_result,
+        matching_and_different_resource_key_downstream.key,
+    )
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_ignores_non_matching_fields_with_matching_upstream():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    matching_result = dg.materialize(
+        [inheritance_upstream],
+        resources={
+            "inheritance_dims": InheritanceDims(letter=GraphDimension(["a"])),
+        },
+        instance=instance,
+    )
+    non_matching_result = dg.materialize(
+        [same_resource_key_different_field_upstream],
+        resources={
+            "inheritance_dims": OtherFieldInheritanceDims(
+                number=GraphDimension(["two"])
+            ),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(inheritance_upstream.key),
+            dg.AssetSpec(same_resource_key_different_field_upstream.key),
+            matching_and_different_field_downstream,
+        ],
+        resources={"inheritance_dims": InheritanceDims()},
+        instance=instance,
+    )
+
+    assert matching_result.success
+    assert non_matching_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [{"letter": "a"}]
+    metadata = _asset_materialization_metadata(
+        downstream_result,
+        matching_and_different_field_downstream.key,
+    )
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_does_not_inherit_from_different_resource_key():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    upstream_result = dg.materialize(
+        [other_resource_key_upstream],
+        resources={
+            "other_inheritance_dims": OtherInheritanceDims(
+                letter=GraphDimension(["a"])
+            ),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(other_resource_key_upstream.key),
+            different_resource_key_downstream,
+        ],
+        resources={"inheritance_dims": InheritanceDims()},
+        instance=instance,
+    )
+
+    assert upstream_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [
+        {"letter": "a"},
+        {"letter": "b"},
+        {"letter": "c"},
+    ]
+
+
+def test_dynamic_graph_asset_can_opt_out_of_dimension_value_inheritance():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    upstream_result = dg.materialize(
+        [inheritance_opt_out_upstream],
+        resources={
+            "inheritance_opt_out_dims": InheritanceOptOutDims(
+                letter=GraphDimension(
+                    ["a"],
+                    inherit_values_from_upstream=False,
+                )
+            ),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(inheritance_opt_out_upstream.key),
+            inheritance_opt_out_downstream,
+        ],
+        resources={"inheritance_opt_out_dims": InheritanceOptOutDims()},
+        instance=instance,
+    )
+
+    assert upstream_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [
+        {"letter": "a"},
+        {"letter": "b"},
+        {"letter": "c"},
+    ]
+
+
+def test_dynamic_graph_asset_inherits_only_enabled_dimensions():
+    _INHERITED_VALUES.clear()
+    instance = dg.DagsterInstance.ephemeral()
+
+    upstream_result = dg.materialize(
+        [mixed_inheritance_upstream],
+        resources={
+            "mixed_inheritance_dims": MixedInheritanceDims(
+                letter=GraphDimension(["a"]),
+                number=GraphDimension(
+                    ["one"],
+                    inherit_values_from_upstream=False,
+                ),
+            ),
+        },
+        instance=instance,
+    )
+    downstream_result = dg.materialize(
+        [
+            dg.AssetSpec(mixed_inheritance_upstream.key),
+            mixed_inheritance_downstream,
+        ],
+        resources={"mixed_inheritance_dims": MixedInheritanceDims()},
+        instance=instance,
+    )
+
+    assert upstream_result.success
+    assert downstream_result.success
+    assert _INHERITED_VALUES == [
+        {"letter": "a", "number": "one"},
+        {"letter": "a", "number": "two"},
+    ]
+    metadata = _asset_materialization_metadata(
+        downstream_result,
+        mixed_inheritance_downstream.key,
+    )
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a", "number": "one"},
+        {"letter": "a", "number": "two"},
+    ]
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_enum_coverage_markdown_all_mode():
+    result = dg.materialize(
+        [dynamic_asset_returns_enum_objects_all],
+        resources={
+            "enum_all_mode_dims": EnumAllModeDims(),
+            "recording_io": dg.IOManagerDefinition.hardcoded_io_manager(
+                RecordingIOManager()
+            ),
+        },
+    )
+
+    assert result.success
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_enum_objects_all.key,
+    )
+    markdown = metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    assert graph_dimensions["coverage"] == {
+        "enum_dimensions": [
+            {
+                "dimension": "letter",
+                "materialized_value_count": 2,
+                "enum_domain_count": 3,
+                "coverage_percent": 2 / 3 * 100,
+            }
+        ],
+        "cartesian_enum_domain": {
+            "materialized_count": 2,
+            "total_domain_count": 3,
+            "coverage_percent": 2 / 3 * 100,
+        },
+    }
+    assert "### Enum Dimension Coverage" in markdown
+    assert "| letter | 2 | 3 | 66.67% |" in markdown
+    assert "### Graph Dimension Domain Coverage" in markdown
+    assert "| 2 | 3 | 66.67% |" in markdown
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_enum_coverage_markdown_first_mode():
+    result = dg.materialize(
+        [dynamic_asset_returns_enum_objects_first],
+        resources={
+            "enum_first_mode_dims": EnumFirstModeDims(),
+            "recording_io": dg.IOManagerDefinition.hardcoded_io_manager(
+                RecordingIOManager()
+            ),
+        },
+    )
+
+    assert result.success
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_enum_objects_first.key,
+    )
+    markdown = metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a"},
+        {"letter": "b"},
+    ]
+    assert graph_dimensions["coverage"] == {
+        "enum_dimensions": [
+            {
+                "dimension": "letter",
+                "materialized_value_count": 2,
+                "enum_domain_count": 3,
+                "coverage_percent": 2 / 3 * 100,
+            }
+        ],
+        "cartesian_enum_domain": {
+            "materialized_count": 2,
+            "total_domain_count": 3,
+            "coverage_percent": 2 / 3 * 100,
+        },
+    }
+    assert "### Enum Dimension Coverage" in markdown
+    assert "| letter | 2 | 3 | 66.67% |" in markdown
+    assert "### Graph Dimension Domain Coverage" in markdown
+    assert "| 2 | 3 | 66.67% |" in markdown
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_first_mode_metadata_records_full_fanout():
+    recording_io = RecordingIOManager()
+
+    result = dg.materialize(
+        [dynamic_asset_returns_multi_enum_objects_first],
+        resources={
+            "first_mode_multi_enum_dims": FirstModeMultiEnumDims(),
+            "recording_io": dg.IOManagerDefinition.hardcoded_io_manager(
+                recording_io
+            ),
+        },
+    )
+
+    assert result.success
+    assert [output["obj"] for output in recording_io.outputs] == [
+        {"letter": "a", "reverse_letter": "x"},
+        {"letter": "a", "reverse_letter": "x"},
+    ]
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_multi_enum_objects_first.key,
+    )
+    markdown = metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    graph_dimensions = _graph_dimensions_metadata(metadata)
+    assert graph_dimensions["materialized"] == [
+        {"letter": "a", "reverse_letter": "x"},
+        {"letter": "a", "reverse_letter": "y"},
+        {"letter": "b", "reverse_letter": "x"},
+        {"letter": "b", "reverse_letter": "y"},
+        {"letter": "c", "reverse_letter": "x"},
+        {"letter": "c", "reverse_letter": "y"},
+    ]
+    assert graph_dimensions["coverage"] == {
+        "enum_dimensions": [
+            {
+                "dimension": "letter",
+                "materialized_value_count": 3,
+                "enum_domain_count": 3,
+                "coverage_percent": 100.0,
+            },
+            {
+                "dimension": "reverse_letter",
+                "materialized_value_count": 2,
+                "enum_domain_count": 3,
+                "coverage_percent": 2 / 3 * 100,
+            },
+        ],
+        "cartesian_enum_domain": {
+            "materialized_count": 6,
+            "total_domain_count": 9,
+            "coverage_percent": 6 / 9 * 100,
+        },
+    }
+    assert "| letter | 3 | 3 | 100.00% |" in markdown
+    assert "| reverse_letter | 2 | 3 | 66.67% |" in markdown
+    assert "| 6 | 9 | 66.67% |" in markdown
+    _assert_legacy_graph_dimension_keys_absent(metadata)
+
+
+def test_dynamic_graph_asset_enum_domain_coverage_multiplies_dimensions():
+    result = dg.materialize(
+        [dynamic_asset_returns_multi_enum_objects],
+        resources={
+            "multi_enum_dims": MultiEnumDims(),
+            "recording_io": dg.IOManagerDefinition.hardcoded_io_manager(
+                RecordingIOManager()
+            ),
+        },
+    )
+
+    assert result.success
+    metadata = _asset_materialization_metadata(
+        result,
+        dynamic_asset_returns_multi_enum_objects.key,
+    )
+    markdown = metadata[_GRAPH_DIMENSIONS_MD_METADATA_KEY].md_str
+    assert _graph_dimensions_metadata(metadata)["materialized"] == [
+        {"letter": "a", "number": "one"},
+        {"letter": "a", "number": "two"},
+        {"letter": "b", "number": "one"},
+        {"letter": "b", "number": "two"},
+    ]
+    assert "| letter | 2 | 3 | 66.67% |" in markdown
+    assert "| number | 2 | 2 | 100.00% |" in markdown
+    assert "### Graph Dimension Domain Coverage" in markdown
+    assert "| 4 | 6 | 66.67% |" in markdown
+    _assert_legacy_graph_dimension_keys_absent(metadata)

--- a/tests/test_dynamic_graph_asset_metadata.py
+++ b/tests/test_dynamic_graph_asset_metadata.py
@@ -5,7 +5,7 @@ from cfa_dagster.azure_adls2.filesystem_io_manager import (
     FilesystemADLS2IOManager,
 )
 from cfa_dagster.azure_adls2.pickle_io_manager import ADLS2PickleIOManager
-from cfa_dagster.dynamic_graph_asset_metadata import (
+from cfa_dagster.dynamic_graph.metadata import (
     DYNAMIC_GRAPH_ASSET_METADATA_KEY,
     SHOULD_INPUT_MANAGER_INHERIT_GRAPH_DIMENSIONS,
     DynamicGraphIOManagerMetadata,
@@ -144,8 +144,6 @@ def test_dynamic_graph_io_manager_metadata_round_trips():
         asset_key_path=["upstream"],
         asset_partition_keys=["2026-08-25"],
         synthetic_partition_keys=["A", "B"],
-        skip_input=True,
-        skip_output=True,
     )
 
     parsed = DynamicGraphIOManagerMetadata.from_metadata(metadata.to_dict())
@@ -197,44 +195,6 @@ def test_filesystem_load_input_patches_inherited_graph_dimensions(monkeypatch):
     )
 
     assert manager.load_input(context) == "loaded"
-
-
-def test_filesystem_load_input_honors_generic_skip(monkeypatch):
-    def fake_load_input(self, context):
-        raise AssertionError("skip_input should return before internal load")
-
-    monkeypatch.setattr(UPathIOManager, "load_input", fake_load_input)
-
-    class FakeInputContext(_FakeInputContext):
-        pass
-
-    manager = object.__new__(FilesystemADLS2IOManager)
-    context = FakeInputContext(
-        definition_metadata=DynamicGraphIOManagerMetadata(
-            skip_input=True
-        ).to_dict(),
-        mapping_key=_encode_mapping_key(("A",)),
-    )
-
-    assert manager.load_input(context) is None
-
-
-def test_filesystem_handle_output_honors_generic_skip(monkeypatch):
-    def fake_handle_output(self, context, obj):
-        raise AssertionError(
-            "skip_output should return before internal output"
-        )
-
-    class FakeOutputContext:
-        output_metadata = DynamicGraphIOManagerMetadata(
-            skip_output=True
-        ).to_dict()
-        log = _FakeLog()
-
-    monkeypatch.setattr(UPathIOManager, "handle_output", fake_handle_output)
-
-    manager = object.__new__(FilesystemADLS2IOManager)
-    assert manager.handle_output(FakeOutputContext(), object()) is None
 
 
 def test_pickle_handle_output_patches_context_before_delegating(monkeypatch):
@@ -303,57 +263,6 @@ def test_pickle_load_input_patches_context_before_delegating(monkeypatch):
     assert manager.load_input(context) == {"loaded": True}
     assert captured["asset_key"] == dg.AssetKey(["pickle_upstream"])
     assert captured["asset_partition_keys"] == ["2026-08-25/A"]
-
-
-def test_pickle_load_input_honors_generic_skip(monkeypatch):
-    class FakeInternalIOManager:
-        def load_input(self, context):
-            raise AssertionError(
-                "skip_input should return before internal load"
-            )
-
-    class FakeInputContext(_FakeInputContext):
-        upstream_output = None
-        log = _FakeLog()
-
-    monkeypatch.setattr(
-        ADLS2PickleIOManager,
-        "_internal_io_manager",
-        property(lambda self: FakeInternalIOManager()),
-    )
-
-    context = FakeInputContext(
-        definition_metadata=DynamicGraphIOManagerMetadata(
-            skip_input=True
-        ).to_dict(),
-        mapping_key=_encode_mapping_key(("A",)),
-    )
-    manager = ADLS2PickleIOManager(overrides={})
-
-    assert manager.load_input(context) is None
-
-
-def test_pickle_handle_output_honors_generic_skip(monkeypatch):
-    class FakeInternalIOManager:
-        def handle_output(self, context, obj):
-            raise AssertionError(
-                "skip_output should return before internal output"
-            )
-
-    class FakeOutputContext:
-        output_metadata = DynamicGraphIOManagerMetadata(
-            skip_output=True
-        ).to_dict()
-        log = _FakeLog()
-
-    monkeypatch.setattr(
-        ADLS2PickleIOManager,
-        "_internal_io_manager",
-        property(lambda self: FakeInternalIOManager()),
-    )
-
-    manager = ADLS2PickleIOManager(overrides={})
-    assert manager.handle_output(FakeOutputContext(), object()) is None
 
 
 def test_pickle_load_input_overrides_short_circuit(monkeypatch):

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -160,7 +160,7 @@ def daily_reports(context: dg.AssetExecutionContext):
 
 ## Dynamic Graph Assets
 
-[Dynamic graph assets](../api.md#cfa_dagster.dynamic_graph_asset.dynamic_graph_asset) combine two existing Dagster concepts, [graph assets](https://docs.dagster.io/guides/build/assets/graph-backed-assets#defining-graph-backed-assets) and [dynamic outputs](https://docs.dagster.io/guides/build/ops/dynamic-graphs#a-dynamic-job), into one decorator to provide easy, runtime-configurable parallelism. Unlike normal Dagster partitions, dynamic graph assets allows you to parallelize logic against more than two dimensions.
+[Dynamic graph assets](../api.md#cfa_dagster.dynamic_graph.asset.dynamic_graph_asset) combine two existing Dagster concepts, [graph assets](https://docs.dagster.io/guides/build/assets/graph-backed-assets#defining-graph-backed-assets) and [dynamic outputs](https://docs.dagster.io/guides/build/ops/dynamic-graphs#a-dynamic-job), into one decorator to provide easy, runtime-configurable parallelism. Unlike normal Dagster partitions, dynamic graph assets allows you to parallelize logic against more than two dimensions.
 
 ```python
 


### PR DESCRIPTION
Closes #109
Closes #159

The primary purpose of this PR is to allow `@dynamic_graph_assets` to inherit dimensions from upstream dependencies to make reruns simpler e.g. If I materialize `usptream_asset` and provide `my_dimension: [a, b]` in the Launchpad, the default automation condition sensor will also materialize `downstream_asset` with `my_dimension: [a, b]` instead of the full `GraphDimension(["a", "b", "c"])`

```python

class SomeDimensions(dg.ConfigurableResource):
  my_dimension: GraphDimension[MyDimension] = GraphDimension(["a", "b", "c"])

@dynamic_graph_asset()
def upstream_asset(some_dimension: SomeDimension):
  return some_dimension.my_dimension.current_value

@dynamic_graph_asset(automation_condition=dg.AutomationCondition.eager())
def downstream_asset(
  some_dimension: SomeDimension,
  upstream_asset
):
  current_dimension = some_dimension.my_dimension.current_value
  print(f"current_dimension: {current_dimension}")
```

Some default metadata was also added to `@dynamic_graph_assets` so you can see which graph dimensions were materialized for a given run. If you use `StrEnums` for you `GraphDimension[SomeStrEnum]`, this metadata will include a calculation of what percentage of the whole enum domain was materialized:
```markdown
### Materialized Graph Dimensions

| letter | reverse_letter |
| --- | --- |
| a | z |
| a | y |
| b | z |
| b | y |
| c | z |
| c | y |

### Enum Dimension Coverage

| Dimension | Materialized values | Enum domain | Coverage |
| --- | ---: | ---: | ---: |
| letter | 3 | 3 | 100.00% |
| reverse_letter | 2 | 3 | 66.67% |

### Graph Dimension Domain Coverage

| Materialized combinations | Total enum domain | Coverage |
| ---: | ---: | ---: |
| 6 | 9 | 66.67% |
```